### PR TITLE
Only support iOS 8+ with CocoaPods

### DIFF
--- a/Argo.podspec
+++ b/Argo.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.source = { :git => 'https://github.com/thoughtbot/Argo.git', :tag => "v#{spec.version}" }
   spec.source_files = 'Argo/**/*.{h,swift}'
   spec.requires_arc = true
-  spec.ios.deployment_target = '7.0'
+  spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
 end
 


### PR DESCRIPTION
As noted in #21, frameworks are an iOS 8+ feature, so setting this to 7.0
doesn't really make sense. We should require 8.0 when installing through
CocoaPods.