### PR TITLE
Fix bad access in JSONValue.parse

### DIFF
--- a/Argo/Globals/JSONValue.swift
+++ b/Argo/Globals/JSONValue.swift
@@ -15,14 +15,14 @@ public extension JSONValue {
   static func parse(json: AnyObject) -> JSONValue {
     switch json {
     case let v as [AnyObject]: return .JSONArray(v.map(parse))
-      
+
     case let v as [String: AnyObject]:
       let object = reduce(v.keys, JSONDict()) { accum, key in
         let value = self.parse(v[key]!)
         return Dictionary.appendKey(accum, key: key, value: value)
       }
       return .JSONObject(object)
-      
+
     case let v as String: return .JSONString(v)
     case let v as NSNumber: return .JSONNumber(v)
     default: return .JSONNull

--- a/Argo/Globals/JSONValue.swift
+++ b/Argo/Globals/JSONValue.swift
@@ -15,14 +15,14 @@ public extension JSONValue {
   static func parse(json: AnyObject) -> JSONValue {
     switch json {
     case let v as [AnyObject]: return .JSONArray(v.map(parse))
-
+      
     case let v as [String: AnyObject]:
       let object = reduce(v.keys, JSONDict()) { accum, key in
-        let append = curry(Dictionary.appendKey)(accum)(key)
-        return (append <^> v[key] >>- self.parse) ?? append(.JSONNull)
+        let value = self.parse(v[key]!)
+        return Dictionary.appendKey(accum, key: key, value: value)
       }
       return .JSONObject(object)
-
+      
     case let v as String: return .JSONString(v)
     case let v as NSNumber: return .JSONNumber(v)
     default: return .JSONNull


### PR DESCRIPTION
Using the following JSON, `JSONValue.parse` would just throw a bad access.

```json
[
  {
    "title": "Foo",
    "age": 21
  },
  {
    "title": "Bar",
    "age": 32
  }
]
```

This makes the `[String: AnyObject]` branch of `parse` work again.
