### PR TITLE
Use Release scheme for tests and make them pass

### DIFF
--- a/Argo.xcodeproj/xcshareddata/xcschemes/Argo-Mac.xcscheme
+++ b/Argo.xcodeproj/xcshareddata/xcschemes/Argo-Mac.xcscheme
@@ -26,7 +26,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Argo.xcodeproj/xcshareddata/xcschemes/Argo-iOS.xcscheme
+++ b/Argo.xcodeproj/xcshareddata/xcschemes/Argo-iOS.xcscheme
@@ -26,7 +26,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ArgoTests/Tests/EmbeddedJSONDecodingTests.swift
+++ b/ArgoTests/Tests/EmbeddedJSONDecodingTests.swift
@@ -4,8 +4,8 @@ import Runes
 
 class EmbeddedJSONDecodingTests: XCTestCase {
   func testCommentDecodingWithEmbeddedUserName() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "comment")
-    let comment = json >>- JSONValue.parse >>- Comment.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "comment")
+    let comment = json >>- Comment.decode
 
     XCTAssert(comment != nil)
     XCTAssert(comment?.id == 6)
@@ -14,8 +14,8 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithEmbeddedUserModel() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "post_no_comments")
-    let post = json >>- JSONValue.parse >>- Post.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "post_no_comments")
+    let post = json >>- Post.decode
 
     XCTAssert(post != nil)
     XCTAssert(post?.id == 3)
@@ -25,8 +25,8 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithEmbeddedUserModelAndComments() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "post_comments")
-    let post = json >>- JSONValue.parse >>- Post.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "post_comments")
+    let post = json >>- Post.decode
 
     XCTAssert(post != nil)
     XCTAssert(post?.id == 3)
@@ -36,8 +36,8 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithBadComments() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "post_bad_comments")
-    let post = json >>- JSONValue.parse >>- Post.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "post_bad_comments")
+    let post = json >>- Post.decode
 
     XCTAssert(post == nil)
   }

--- a/ArgoTests/Tests/EquatableSpec.swift
+++ b/ArgoTests/Tests/EquatableSpec.swift
@@ -4,19 +4,16 @@ import Runes
 
 class EquatableSpec: XCTestCase {
   func testEqualJSONObjects() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "types")
-    let parsed = json >>- JSONValue.parse
-    let anotherParsed = json >>- JSONValue.parse
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "types")
+    let anotherParsed = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "types")
 
-    XCTAssertEqual(parsed!, anotherParsed!)
+    XCTAssertEqual(json!, anotherParsed!)
   }
 
   func testNotEqualJSONObjects() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "types")
-    let anotherJSON: AnyObject? = JSONFileReader.JSON(fromFile: "types_fail_embedded")
-    let parsed = json >>- JSONValue.parse
-    let anotherParsed = anotherJSON >>- JSONValue.parse
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "types")
+    let anotherJSON = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "types_fail_embedded")
 
-    XCTAssertNotEqual(parsed!, anotherParsed!)
+    XCTAssertNotEqual(json!, anotherJSON!)
   }
 }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -4,16 +4,16 @@ import Runes
 
 class ExampleTests: XCTestCase {
   func testJSONWithRootArray() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "array_root")
-    let stringArray: [String]? = json >>- JSONValue.parse >>- JSONValue.mapDecode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "array_root")
+    let stringArray: [String]? = json >>- JSONValue.mapDecode
 
     XCTAssertNotNil(stringArray)
     XCTAssertEqual(stringArray!, ["foo", "bar", "baz"])
   }
 
   func testJSONWithRootObject() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "root_object")
-    let user: User? = json >>- JSONValue.parse >>- { $0["user"] >>- User.decode }
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "root_object")
+    let user: User? = json >>- { $0["user"] >>- User.decode }
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -23,8 +23,8 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingNonFinalClass() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "url")
-    let url: NSURL? = json >>- JSONValue.parse >>- { $0["url"] >>- NSURL.decode }
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "url")
+    let url: NSURL? = json >>- { $0["url"] >>- NSURL.decode }
 
     XCTAssert(url != nil)
     XCTAssert(url?.absoluteString == "http://example.com")
@@ -32,9 +32,8 @@ class ExampleTests: XCTestCase {
 
   func testDecodingJSONWithRootArray() {
     let expected = JSONValue.parse([["title": "Foo", "age": 21], ["title": "Bar", "age": 32]])
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "root_array")
-    let parsed = json >>- JSONValue.parse
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "root_array")
 
-    XCTAssert(.Some(expected) == parsed)
+    XCTAssert(.Some(expected) == json)
   }
 }

--- a/ArgoTests/Tests/OptionalPropertyDecodingTests.swift
+++ b/ArgoTests/Tests/OptionalPropertyDecodingTests.swift
@@ -4,8 +4,8 @@ import Runes
 
 class OptionalPropertyDecodingTests: XCTestCase {
   func testUserDecodingWithEmail() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "user_with_email")
-    let user = json >>- JSONValue.parse >>- User.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "user_with_email")
+    let user = json >>- User.decode
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -15,8 +15,8 @@ class OptionalPropertyDecodingTests: XCTestCase {
   }
 
   func testUserDecodingWithoutEmail() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "user_without_email")
-    let user = json >>- JSONValue.parse >>- User.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "user_without_email")
+    let user = json >>- User.decode
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)

--- a/ArgoTests/Tests/TypeTests.swift
+++ b/ArgoTests/Tests/TypeTests.swift
@@ -4,8 +4,8 @@ import Runes
 
 class TypeTests: XCTestCase {
   func testAllTheTypes() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "types")
-    let model = json >>- JSONValue.parse >>- TestModel.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "types")
+    let model = json >>- TestModel.decode
 
     XCTAssert(model != nil)
     XCTAssert(model?.int == 5)
@@ -24,8 +24,8 @@ class TypeTests: XCTestCase {
   }
 
   func testFailingEmbedded() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "types_fail_embedded")
-    let model = json >>- JSONValue.parse >>- TestModel.decode
+    let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "types_fail_embedded")
+    let model = json >>- TestModel.decode
 
     XCTAssert(model == nil)
   }


### PR DESCRIPTION
It's embarrassing how many times we've made this `bind`/`fmap` mistake.
I really wish Swift would prevent this from compiling in the first
place.