### PR TITLE
Use static func instead of class func

### DIFF
--- a/Argo/Protocols/JSONDecodable.swift
+++ b/Argo/Protocols/JSONDecodable.swift
@@ -1,4 +1,4 @@
 public protocol JSONDecodable {
   typealias DecodedType = Self
-  class func decode(JSONValue) -> DecodedType?
+  static func decode(JSONValue) -> DecodedType?
 }


### PR DESCRIPTION
The only change needed for Swift 1.2 support.