### PR TITLE
Update for Swift 1.2

### DIFF
--- a/Argo/Globals/JSONValue.swift
+++ b/Argo/Globals/JSONValue.swift
@@ -31,7 +31,7 @@ public extension JSONValue {
 
   static func mapDecode<A where A: JSONDecodable, A == A.DecodedType>(value: JSONValue) -> [A]? {
     switch value {
-    case let .JSONArray(a): return sequence(a.map { A.decode($0) })
+    case let .JSONArray(a): return sequence(A.decode <^> a)
     default: return .None
     }
   }

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -4,11 +4,7 @@ import Runes
 
 // Pull embedded value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSONValue, keys: [String]) -> A? {
-  if let o = json.find(keys) {
-    return A.decode(o)
-  }
-
-  return .None
+  return json.find(keys) >>- A.decode
 }
 
 // Pull value from JSON

--- a/Argo/Protocols/JSONDecodable.swift
+++ b/Argo/Protocols/JSONDecodable.swift
@@ -1,4 +1,4 @@
 public protocol JSONDecodable {
   typealias DecodedType = Self
-  class func decode(JSONValue) -> DecodedType?
+  static func decode(JSONValue) -> DecodedType?
 }


### PR DESCRIPTION
This updates Argo to be compatible with Swift 1.2b. The only changed needed was `class` to `struct` in the `JSONDecode` protocol `decode` function.

Also, with the update came many stability fixes allowing us to partially apply functions from generic protocol static functions.