### PR TITLE
Floats not JSONDecodable

### DIFF
--- a/Argo/Globals/JSON.swift
+++ b/Argo/Globals/JSON.swift
@@ -23,3 +23,9 @@ extension Bool: JSONDecodable {
     return j.value()
   }
 }
+
+extension Float: JSONDecodable {
+  public static func decode(j: JSONValue) -> Float? {
+    return j.value()
+  }
+}

--- a/ArgoTests/JSON/types.json
+++ b/ArgoTests/JSON/types.json
@@ -1,6 +1,7 @@
 {
   "int": 5,
   "double": 3.4,
+  "float": 1.1,
   "bool": false,
   "int_opt": 4,
   "string_array": [

--- a/ArgoTests/Models/TestModel.swift
+++ b/ArgoTests/Models/TestModel.swift
@@ -5,6 +5,7 @@ struct TestModel {
   let int: Int
   let string: String
   let double: Double
+  let float: Float
   let bool: Bool
   let intOpt: Int?
   let stringArray: [String]
@@ -15,8 +16,8 @@ struct TestModel {
 }
 
 extension TestModel: JSONDecodable {
-  static func create(int: Int)(string: String)(double: Double)(bool: Bool)(intOpt: Int?)(stringArray: [String])(stringArrayOpt: [String]?)(eStringArray: [String])(eStringArrayOpt: [String]?)(userOpt: User?) -> TestModel {
-    return TestModel(int: int, string: string, double: double, bool: bool, intOpt: intOpt, stringArray: stringArray, stringArrayOpt: stringArrayOpt, eStringArray: eStringArray, eStringArrayOpt: eStringArrayOpt, userOpt: userOpt)
+  static func create(int: Int)(string: String)(double: Double)(float: Float)(bool: Bool)(intOpt: Int?)(stringArray: [String])(stringArrayOpt: [String]?)(eStringArray: [String])(eStringArrayOpt: [String]?)(userOpt: User?) -> TestModel {
+    return TestModel(int: int, string: string, double: double, float: float, bool: bool, intOpt: intOpt, stringArray: stringArray, stringArrayOpt: stringArrayOpt, eStringArray: eStringArray, eStringArrayOpt: eStringArrayOpt, userOpt: userOpt)
   }
 
   static func decode(j: JSONValue) -> TestModel? {
@@ -24,6 +25,7 @@ extension TestModel: JSONDecodable {
       <^> j <| "int"
       <*> j <| ["user_opt", "name"]
       <*> j <| "double"
+      <*> j <| "float"
       <*> j <| "bool"
       <*> j <|? "int_opt"
       <*> j <|| "string_array"

--- a/ArgoTests/Tests/TypeTests.swift
+++ b/ArgoTests/Tests/TypeTests.swift
@@ -11,6 +11,7 @@ class TypeTests: XCTestCase {
     XCTAssert(model?.int == 5)
     XCTAssert(model?.string == "Cooler User")
     XCTAssert(model?.double == 3.4)
+    XCTAssert(model?.float == 1.1)
     XCTAssert(model?.bool == false)
     XCTAssert(model?.intOpt != nil)
     XCTAssert(model?.intOpt! == 4)


### PR DESCRIPTION
```swift
import Foundation
import Argo
import Runes

struct Location {
  let latitude: Float
  let longitude: Float
}

extension Location: JSONDecodable {
  static func create(latitude: Float)(longitude: Float) -> Location {
    return Location(latitude: latitude, longitude: longitude)
  }

  static func decode(json: JSONValue) -> Location? {
    return Location.create
      <^> json <| "latitude"
      <*> json <| "longitude"
  }
}
```

This structs causes SourceKit to hang forever. I got no error at first, until I removed all other properties, then I got this: `Type Float does not conform to protocol JSONDecodable`.