### PR TITLE
Clarify that Runes isn't an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ The Greek word for _swift_ and the ship used by Jason, son of Aeson, of the
 Argonauts. Aeson is the JSON parsing library in Haskell that inspired Argo,
 much like Aeson inspired his son Jason.
 
-NOTE: The master branch of Argo is pushing ahead with Swift 1.2 support. Support for 
-Swift 1.1 can be found on branch [swift-1.1] and with tag version v0.3.2.
+NOTE: The master branch of Argo is pushing ahead with Swift 1.2 support.
+Support for Swift 1.1 can be found on branch [swift-1.1] and in the 0.3.x
+versions of tags/releases.
 
 [swift-1.1]: https://github.com/thoughtbot/Argo/tree/swift-1.1
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ for up to date installation instructions.
 
 [carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
 
-If you want to use the functional operators (`<^>`, `<*>`, `>>-`) in your app,
-you'll also need to add `Runes.framework` to your project. [Runes] is a
+You'll also need to add `Runes.framework` to your project. [Runes] is a
 dependency of Argo, so you don't need to specify it in your Cartfile.
 
 [Runes]: https://github.com/thoughtbot/runes
@@ -56,6 +55,8 @@ I guess you could do it this way if that's your thing.
 
 Add this repo as a submodule, and add the project file to your workspace. You
 can then link against `Argo.framework` for your application target.
+
+You'll also need to add [Runes] to your project the same way.
 
 ## Usage tl;dr:
 


### PR DESCRIPTION
Runes needs to be added to the client application in order for Argo to work.
Given that it isn't an optional dependency, we should be clearer about that in
the documentation.