### PR TITLE
Fix EXC_BAD_ACCESS on 32 bit systems

### DIFF
--- a/Argo/Globals/JSONValue.swift
+++ b/Argo/Globals/JSONValue.swift
@@ -31,7 +31,7 @@ public extension JSONValue {
 
   static func mapDecode<A where A: JSONDecodable, A == A.DecodedType>(value: JSONValue) -> [A]? {
     switch value {
-    case let .JSONArray(a): return sequence(A.decode <^> a)
+    case let .JSONArray(a): return sequence({ A.decode($0) } <^> a)
     default: return .None
     }
   }

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -4,7 +4,7 @@ import Runes
 
 // Pull embedded value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSONValue, keys: [String]) -> A? {
-  return json.find(keys) >>- A.decode
+  return json.find(keys) >>- { A.decode($0) }
 }
 
 // Pull value from JSON


### PR DESCRIPTION
It looks like even in Swift 1.2, partially applying static functions on a
generic protocol object causes a crash, but only on 32 bit systems. We had
originally thought these were fixed with Swift 1.2, but apparently the fix
didn't completely take for 32 bit systems.

Fixes #54