### PR TITLE
Remove value function

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -179,8 +179,6 @@
 		F89335541A4CE83000B88685 /* Argo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Argo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F893355E1A4CE83000B88685 /* Argo-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Argo-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F893356D1A4CE8FC00B88685 /* Argo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Argo.h; sourceTree = "<group>"; };
-		F8C05D441A649A04004A8D0F /* Runes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Runes.framework; path = "../Carthage/Checkouts/runes/build/Debug-iphoneos/Runes.framework"; sourceTree = "<group>"; };
-		F8C05D461A649A08004A8D0F /* Runes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Runes.framework; path = ../Carthage/Checkouts/runes/build/Debug/Runes.framework; sourceTree = "<group>"; };
 		F8CBE6621A64508200316FBC /* sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sequence.swift; sourceTree = "<group>"; };
 		F8CBE6661A64521000316FBC /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		F8E33FA11A51DE020025A6E5 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = curry.swift; sourceTree = "<group>"; };
@@ -257,7 +255,6 @@
 				EAD9FAF019D0F7150031E006 /* Globals */,
 				EAD9FAE919D0F6480031E006 /* Operators */,
 				EAD9FAE819D0F5B50031E006 /* Resources */,
-				F8C05D411A6499CE004A8D0F /* Frameworks */,
 			);
 			name = Argo;
 			path = ../Argo/Argo;
@@ -390,15 +387,6 @@
 			);
 			name = Mac;
 			path = Carthage/Build/Mac;
-			sourceTree = "<group>";
-		};
-		F8C05D411A6499CE004A8D0F /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F8C05D461A649A08004A8D0F /* Runes.framework */,
-				F8C05D441A649A04004A8D0F /* Runes.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		F8CBE6651A6451F800316FBC /* Extensions */ = {

--- a/Argo/Globals/JSON.swift
+++ b/Argo/Globals/JSON.swift
@@ -3,31 +3,46 @@ import Runes
 
 extension String: JSONDecodable {
   public static func decode(j: JSONValue) -> String? {
-    return j.value()
+    switch j {
+    case let .JSONString(s): return s
+    default: return .None
+    }
   }
 }
 
 extension Int: JSONDecodable {
   public static func decode(j: JSONValue) -> Int? {
-    return j.value()
+    switch j {
+    case let .JSONNumber(n): return n as Int
+    default: return .None
+    }
   }
 }
 
 extension Double: JSONDecodable {
   public static func decode(j: JSONValue) -> Double? {
-    return j.value()
+    switch j {
+    case let .JSONNumber(n): return n as Double
+    default: return .None
+    }
   }
 }
 
 extension Bool: JSONDecodable {
   public static func decode(j: JSONValue) -> Bool? {
-    return j.value()
+    switch j {
+    case let .JSONNumber(n): return n as Bool
+    default: return .None
+    }
   }
 }
 
 extension Float: JSONDecodable {
   public static func decode(j: JSONValue) -> Float? {
-    return j.value()
+    switch j {
+    case let .JSONNumber(n): return n as Float
+    default: return .None
+    }
   }
 }
 

--- a/Argo/Globals/JSONValue.swift
+++ b/Argo/Globals/JSONValue.swift
@@ -31,16 +31,6 @@ public extension JSONValue {
 }
 
 public extension JSONValue {
-  func value<A>() -> A? {
-    switch self {
-    case let .JSONString(v): return v as? A
-    case let .JSONNumber(v): return v as? A
-    case let .JSONNull: return .None
-    case let .JSONArray(a): return a as? A
-    case let .JSONObject(o): return o as? A
-    }
-  }
-
   subscript(key: String) -> JSONValue? {
     switch self {
     case let .JSONObject(o): return o[key]


### PR DESCRIPTION
The value function is not needed because we can pull the values out of the
JSONValue enum with a switch statement. This was also the source of some
confusion with `JSONValue.value()` and unnecessary complexity with more
type inference.