### PR TITLE
Move JSONValue.mapDecode to a global function

### DIFF
--- a/Argo/Globals/JSON.swift
+++ b/Argo/Globals/JSON.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Runes
 
 extension String: JSONDecodable {
   public static func decode(j: JSONValue) -> String? {
@@ -27,5 +28,12 @@ extension Bool: JSONDecodable {
 extension Float: JSONDecodable {
   public static func decode(j: JSONValue) -> Float? {
     return j.value()
+  }
+}
+
+public func decodeArray<A where A: JSONDecodable, A == A.DecodedType>(value: JSONValue) -> [A]? {
+  switch value {
+  case let .JSONArray(a): return sequence({ A.decode($0) } <^> a)
+  default: return .None
   }
 }

--- a/Argo/Globals/JSONValue.swift
+++ b/Argo/Globals/JSONValue.swift
@@ -28,13 +28,6 @@ public extension JSONValue {
     default: return .JSONNull
     }
   }
-
-  static func mapDecode<A where A: JSONDecodable, A == A.DecodedType>(value: JSONValue) -> [A]? {
-    switch value {
-    case let .JSONArray(a): return sequence({ A.decode($0) } <^> a)
-    default: return .None
-    }
-  }
 }
 
 public extension JSONValue {

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -26,7 +26,7 @@ public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSONValue, k
 
 // Pull embedded array from JSON
 public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSONValue, keys: [String]) -> [A]? {
-  return json.find(keys) >>- JSONValue.mapDecode
+  return json.find(keys) >>- decodeArray
 }
 
 // Pull array from JSON

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -5,7 +5,7 @@ import Runes
 class ExampleTests: XCTestCase {
   func testJSONWithRootArray() {
     let json = JSONValue.parse <^> JSONFileReader.JSON(fromFile: "array_root")
-    let stringArray: [String]? = json >>- JSONValue.mapDecode
+    let stringArray: [String]? = json >>- decodeArray
 
     XCTAssertNotNil(stringArray)
     XCTAssertEqual(stringArray!, ["foo", "bar", "baz"])


### PR DESCRIPTION
This was kind of bolted onto JSONValue without too much benefit. It was
also pretty poorly named. It makes more sense to me as a global
function, seeing as it's essentially already a workaround for the fact
that we can't create an extension on Array with a type constraint of
JSONDecodable.