### PR TITLE
Remove JSON subscripting

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		F89335721A4CE93600B88685 /* StandardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FAF319D0F74C0031E006 /* StandardTypes.swift */; };
 		F89335741A4CE93600B88685 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FAEA19D0F6930031E006 /* Operators.swift */; };
 		F89335761A4CE93600B88685 /* JSONOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FAF519D0F7900031E006 /* JSONOperators.swift */; };
+		F8A1ACF81A9CE15200118B29 /* fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1ACF71A9CE15200118B29 /* fold.swift */; };
+		F8A1ACF91A9CE34500118B29 /* fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1ACF71A9CE15200118B29 /* fold.swift */; };
 		F8CBE6631A64508200316FBC /* sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6621A64508200316FBC /* sequence.swift */; };
 		F8CBE6641A6450F200316FBC /* sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6621A64508200316FBC /* sequence.swift */; };
 		F8CBE6671A64521000316FBC /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6661A64521000316FBC /* Dictionary.swift */; };
@@ -191,6 +193,7 @@
 		F89335541A4CE83000B88685 /* Argo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Argo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F893355E1A4CE83000B88685 /* Argo-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Argo-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F893356D1A4CE8FC00B88685 /* Argo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Argo.h; sourceTree = "<group>"; };
+		F8A1ACF71A9CE15200118B29 /* fold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = fold.swift; sourceTree = "<group>"; };
 		F8CBE6621A64508200316FBC /* sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sequence.swift; sourceTree = "<group>"; };
 		F8CBE6661A64521000316FBC /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		F8E33FA11A51DE020025A6E5 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = curry.swift; sourceTree = "<group>"; };
@@ -327,6 +330,7 @@
 				EAD9FB1919D4B23F0031E006 /* JSON.swift */,
 				F8E33FA11A51DE020025A6E5 /* curry.swift */,
 				F8CBE6621A64508200316FBC /* sequence.swift */,
+				F8A1ACF71A9CE15200118B29 /* fold.swift */,
 			);
 			path = Globals;
 			sourceTree = "<group>";
@@ -649,6 +653,7 @@
 				EAD9FB1A19D4B23F0031E006 /* JSON.swift in Sources */,
 				EAD9FAEB19D0F6930031E006 /* Operators.swift in Sources */,
 				EAD9FAF619D0F7900031E006 /* JSONOperators.swift in Sources */,
+				F8A1ACF81A9CE15200118B29 /* fold.swift in Sources */,
 				EAD9FAF919D0F7CA0031E006 /* JSONDecodable.swift in Sources */,
 				F8E33FA21A51DE020025A6E5 /* curry.swift in Sources */,
 				EAD9FAF419D0F74C0031E006 /* StandardTypes.swift in Sources */,
@@ -685,6 +690,7 @@
 				F8CBE6641A6450F200316FBC /* sequence.swift in Sources */,
 				F862E0AA1A519D360093B028 /* JSON.swift in Sources */,
 				F89335741A4CE93600B88685 /* Operators.swift in Sources */,
+				F8A1ACF91A9CE34500118B29 /* fold.swift in Sources */,
 				F89335701A4CE92D00B88685 /* JSONDecodable.swift in Sources */,
 				F89335761A4CE93600B88685 /* JSONOperators.swift in Sources */,
 				F8E33FA31A51DE510025A6E5 /* curry.swift in Sources */,

--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -70,8 +70,8 @@
 		F89335721A4CE93600B88685 /* StandardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FAF319D0F74C0031E006 /* StandardTypes.swift */; };
 		F89335741A4CE93600B88685 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FAEA19D0F6930031E006 /* Operators.swift */; };
 		F89335761A4CE93600B88685 /* JSONOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FAF519D0F7900031E006 /* JSONOperators.swift */; };
-		F8A1ACF81A9CE15200118B29 /* fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1ACF71A9CE15200118B29 /* fold.swift */; };
-		F8A1ACF91A9CE34500118B29 /* fold.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1ACF71A9CE15200118B29 /* fold.swift */; };
+		F8A1ACF81A9CE15200118B29 /* flatReduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1ACF71A9CE15200118B29 /* flatReduce.swift */; };
+		F8A1ACF91A9CE34500118B29 /* flatReduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A1ACF71A9CE15200118B29 /* flatReduce.swift */; };
 		F8CBE6631A64508200316FBC /* sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6621A64508200316FBC /* sequence.swift */; };
 		F8CBE6641A6450F200316FBC /* sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6621A64508200316FBC /* sequence.swift */; };
 		F8CBE6671A64521000316FBC /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6661A64521000316FBC /* Dictionary.swift */; };
@@ -193,7 +193,7 @@
 		F89335541A4CE83000B88685 /* Argo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Argo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F893355E1A4CE83000B88685 /* Argo-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Argo-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F893356D1A4CE8FC00B88685 /* Argo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Argo.h; sourceTree = "<group>"; };
-		F8A1ACF71A9CE15200118B29 /* fold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = fold.swift; sourceTree = "<group>"; };
+		F8A1ACF71A9CE15200118B29 /* flatReduce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = flatReduce.swift; sourceTree = "<group>"; };
 		F8CBE6621A64508200316FBC /* sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sequence.swift; sourceTree = "<group>"; };
 		F8CBE6661A64521000316FBC /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		F8E33FA11A51DE020025A6E5 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = curry.swift; sourceTree = "<group>"; };
@@ -330,7 +330,7 @@
 				EAD9FB1919D4B23F0031E006 /* JSON.swift */,
 				F8E33FA11A51DE020025A6E5 /* curry.swift */,
 				F8CBE6621A64508200316FBC /* sequence.swift */,
-				F8A1ACF71A9CE15200118B29 /* fold.swift */,
+				F8A1ACF71A9CE15200118B29 /* flatReduce.swift */,
 			);
 			path = Globals;
 			sourceTree = "<group>";
@@ -653,7 +653,7 @@
 				EAD9FB1A19D4B23F0031E006 /* JSON.swift in Sources */,
 				EAD9FAEB19D0F6930031E006 /* Operators.swift in Sources */,
 				EAD9FAF619D0F7900031E006 /* JSONOperators.swift in Sources */,
-				F8A1ACF81A9CE15200118B29 /* fold.swift in Sources */,
+				F8A1ACF81A9CE15200118B29 /* flatReduce.swift in Sources */,
 				EAD9FAF919D0F7CA0031E006 /* JSONDecodable.swift in Sources */,
 				F8E33FA21A51DE020025A6E5 /* curry.swift in Sources */,
 				EAD9FAF419D0F74C0031E006 /* StandardTypes.swift in Sources */,
@@ -690,7 +690,7 @@
 				F8CBE6641A6450F200316FBC /* sequence.swift in Sources */,
 				F862E0AA1A519D360093B028 /* JSON.swift in Sources */,
 				F89335741A4CE93600B88685 /* Operators.swift in Sources */,
-				F8A1ACF91A9CE34500118B29 /* fold.swift in Sources */,
+				F8A1ACF91A9CE34500118B29 /* flatReduce.swift in Sources */,
 				F89335701A4CE92D00B88685 /* JSONDecodable.swift in Sources */,
 				F89335761A4CE93600B88685 /* JSONOperators.swift in Sources */,
 				F8E33FA31A51DE510025A6E5 /* curry.swift in Sources */,

--- a/Argo/Globals/JSON.swift
+++ b/Argo/Globals/JSON.swift
@@ -27,18 +27,10 @@ public extension JSON {
   }
 }
 
-public extension JSON {
-  subscript(key: Swift.String) -> JSON? {
-    switch self {
-    case let .Object(o): return o[key]
-    default: return .None
-    }
+extension JSON: JSONDecodable {
+  public static func decode(j: JSON) -> JSON? {
+    return j
   }
-
-  func find(keys: [Swift.String]) -> JSON? {
-    return keys.reduce(self) { $0?[$1] }
-  }
-
 }
 
 extension JSON: Printable {

--- a/Argo/Globals/flatReduce.swift
+++ b/Argo/Globals/flatReduce.swift
@@ -1,0 +1,7 @@
+import Runes
+
+func flatReduce<S: SequenceType, U>(sequence: S, initial: U, combine: (U, S.Generator.Element) -> U?) -> U? {
+  return reduce(sequence, initial) { accum, x in
+    accum >>- { combine($0, x) }
+  }
+}

--- a/Argo/Globals/fold.swift
+++ b/Argo/Globals/fold.swift
@@ -1,7 +1,0 @@
-import Runes
-
-func foldM<S: SequenceType, U>(sequence: S, initial: U, combine: (U, S.Generator.Element) -> U?) -> U? {
-  return reduce(sequence, initial) { accum, x in
-    accum >>- { combine($0, x) }
-  }
-}

--- a/Argo/Globals/fold.swift
+++ b/Argo/Globals/fold.swift
@@ -1,0 +1,7 @@
+import Runes
+
+func foldM<S: SequenceType, U>(sequence: S, initial: U, combine: (U, S.Generator.Element) -> U?) -> U? {
+  return reduce(sequence, initial) { accum, x in
+    accum >>- { combine($0, x) }
+  }
+}

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -2,11 +2,6 @@ import Runes
 
 // MARK: Values
 
-// Pull embedded value from JSON
-public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
-  return foldM(keys, json, <|) >>- { A.decode($0) }
-}
-
 // Pull value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> A? {
   switch json {
@@ -15,35 +10,39 @@ public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: St
   }
 }
 
-// Pull embedded optional value from JSON
-public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A?? {
-  return pure(json <| keys)
-}
-
 // Pull optional value from JSON
 public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> A?? {
   return pure(json <| key)
 }
 
-// MARK: Arrays
-
-// Pull embedded array from JSON
-public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> [A]? {
-  return json <| keys >>- decodeArray
+// Pull embedded value from JSON
+public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
+  return foldM(keys, json, <|) >>- { A.decode($0) }
 }
+
+// Pull embedded optional value from JSON
+public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A?? {
+  return pure(json <| keys)
+}
+
+// MARK: Arrays
 
 // Pull array from JSON
 public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> [A]? {
   return json <| key >>- decodeArray
 }
 
+// Pull optional array from JSON
+public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> [A]?? {
+  return pure(json <|| key)
+}
+
+// Pull embedded array from JSON
+public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> [A]? {
+  return json <| keys >>- decodeArray
+}
 
 // Pull embedded optional array from JSON
 public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> [A]?? {
   return pure(json <|| keys)
-}
-
-// Pull optional array from JSON
-public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> [A]?? {
-  return pure(json <|| key)
 }

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -4,9 +4,7 @@ import Runes
 
 // Pull embedded value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
-  return reduce(keys, json) { accum, key in
-    accum >>- { $0 <| key }
-    } >>- { A.decode($0) }
+  return foldM(keys, json, <|) >>- { A.decode($0) }
 }
 
 // Pull value from JSON

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -17,7 +17,7 @@ public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: S
 
 // Pull embedded value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
-  return foldM(keys, json, <|) >>- { A.decode($0) }
+  return flatReduce(keys, json, <|) >>- { A.decode($0) }
 }
 
 // Pull embedded optional value from JSON

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -4,12 +4,17 @@ import Runes
 
 // Pull embedded value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
-  return json.find(keys) >>- { A.decode($0) }
+  return reduce(keys, json) { accum, key in
+    accum >>- { $0 <| key }
+    } >>- { A.decode($0) }
 }
 
 // Pull value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> A? {
-  return json <| [key]
+  switch json {
+  case let .Object(o): return o[key] >>- { A.decode($0) }
+  default: return .None
+  }
 }
 
 // Pull embedded optional value from JSON
@@ -19,19 +24,19 @@ public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: 
 
 // Pull optional value from JSON
 public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> A?? {
-  return json <|? [key]
+  return pure(json <| key)
 }
 
 // MARK: Arrays
 
 // Pull embedded array from JSON
 public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> [A]? {
-  return json.find(keys) >>- decodeArray
+  return json <| keys >>- decodeArray
 }
 
 // Pull array from JSON
 public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> [A]? {
-  return json <|| [key]
+  return json <| key >>- decodeArray
 }
 
 
@@ -42,5 +47,5 @@ public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys:
 
 // Pull optional array from JSON
 public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> [A]?? {
-  return json <||? [key]
+  return pure(json <|| key)
 }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -13,7 +13,7 @@ class ExampleTests: XCTestCase {
 
   func testJSONWithRootObject() {
     let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "root_object")
-    let user: User? = json >>- { $0["user"] >>- User.decode }
+    let user: User? = json >>- { $0 <| "user" >>- User.decode }
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -24,7 +24,7 @@ class ExampleTests: XCTestCase {
 
   func testDecodingNonFinalClass() {
     let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "url")
-    let url: NSURL? = json >>- { $0["url"] >>- NSURL.decode }
+    let url: NSURL? = json >>- { $0 <| "url" >>- NSURL.decode }
 
     XCTAssert(url != nil)
     XCTAssert(url?.absoluteString == "http://example.com")


### PR DESCRIPTION
This removes the ability to subscript JSON values, instead opting to
centralize around the `<|` operators for pulling out values.

Fixes #63