### PR TITLE
Remove closures in favor of partial application

### DIFF
--- a/Argo/Globals/StandardTypes.swift
+++ b/Argo/Globals/StandardTypes.swift
@@ -48,7 +48,7 @@ extension Float: JSONDecodable {
 
 public func decodeArray<A where A: JSONDecodable, A == A.DecodedType>(value: JSON) -> [A]? {
   switch value {
-  case let .Array(a): return sequence({ A.decode($0) } <^> a)
+  case let .Array(a): return sequence(A.decode <^> a)
   default: return .None
   }
 }

--- a/Argo/Operators/JSONOperators.swift
+++ b/Argo/Operators/JSONOperators.swift
@@ -5,7 +5,7 @@ import Runes
 // Pull value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> A? {
   switch json {
-  case let .Object(o): return o[key] >>- { A.decode($0) }
+  case let .Object(o): return o[key] >>- A.decode
   default: return .None
   }
 }
@@ -17,7 +17,7 @@ public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: S
 
 // Pull embedded value from JSON
 public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
-  return flatReduce(keys, json, <|) >>- { A.decode($0) }
+  return flatReduce(keys, json, <|) >>- A.decode
 }
 
 // Pull embedded optional value from JSON


### PR DESCRIPTION
There was a bug in Swift before version 1.2 beta 3 that meant we had to
wrap these partial application sections in a closure in order to avoid
segfaults. As of 1.2 beta 3, this bug in Swift has been fixed, so we can
remove the explicit closures and just apply the functions the way god
intended.

![](http://dl.dropboxusercontent.com/u/452364/gifs/cable-dance.gif)