### PR TITLE
Add .fromOptional to Decoded

### DIFF
--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -12,12 +12,21 @@ public enum Decoded<T> {
     default: return .None
     }
   }
+}
 
-  public static func optional<A>(p: Decoded<A>) -> Decoded<A?> {
-    switch p {
+public extension Decoded {
+  static func optional<T>(x: Decoded<T>) -> Decoded<T?> {
+    switch x {
     case let .Success(box): return .Success(Box(.Some(box.value)))
     case let .MissingKey(string): return .Success(Box(.None))
     case let .TypeMismatch(string): return .TypeMismatch(string)
+    }
+  }
+
+  static func fromOptional<T>(x: T?) -> Decoded<T> {
+    switch x {
+    case let .Some(value): return .Success(Box(value))
+    case .None: return .TypeMismatch("Expected .Some(\(T.self)), got .None")
     }
   }
 }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -35,4 +35,22 @@ class ExampleTests: XCTestCase {
 
     XCTAssert(.Some(expected) == json)
   }
+
+  func testFlatMapOptionals() {
+    let json: AnyObject? = JSONFileReader.JSON(fromFile: "user_with_email")
+    let user: User? = json >>- decode
+
+    XCTAssert(user?.id == 1)
+    XCTAssert(user?.name == "Cool User")
+    XCTAssert(user?.email == "u.cool@example.com")
+  }
+
+  func testFlatMapDecoded() {
+    let json: AnyObject? = JSONFileReader.JSON(fromFile: "user_with_email")
+    let user: Decoded<User> = .fromOptional(json) >>- decode
+
+    XCTAssert(user.value?.id == 1)
+    XCTAssert(user.value?.name == "Cool User")
+    XCTAssert(user.value?.email == "u.cool@example.com")
+  }
 }


### PR DESCRIPTION
`.fromOptional` converts `T?` into `Decoded<T>`, which makes it easier
to `flatMap` the `AnyObject?` returned from `NSJSONSerialization` into
`decode` and get back a `Decoded<T>`.