### PR TITLE
Add 'import Runes' to README tl;dr

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ You'll also need to add [Runes] to your project the same way.
 ## Usage tl;dr:
 
 ```swift
+import Argo
+import Runes
+
 struct User {
   let id: Int
   let name: String


### PR DESCRIPTION
Add import statements to the tl;dr, as the map and apply operators are a part of Runes and require more than "import Argo" to compile. It took me a while to figure this out. 