### PR TITLE
Rename JSONDecodable to Decodable

### DIFF
--- a/Argo/Functions/decode.swift
+++ b/Argo/Functions/decode.swift
@@ -1,15 +1,15 @@
-public func decode<T: JSONDecodable where T == T.DecodedType>(object: AnyObject) -> T? {
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> T? {
   return decode(object).value
 }
 
-public func decode<T: JSONDecodable where T == T.DecodedType>(object: AnyObject) -> [T]? {
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> [T]? {
   return decode(object).value
 }
 
-public func decode<T: JSONDecodable where T == T.DecodedType>(object: AnyObject) -> Decoded<T> {
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> Decoded<T> {
   return T.decode(JSON.parse(object))
 }
 
-public func decode<T: JSONDecodable where T == T.DecodedType>(object: AnyObject) -> Decoded<[T]> {
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> Decoded<[T]> {
   return decodeArray(JSON.parse(object))
 }

--- a/Argo/Operators/Operators.swift
+++ b/Argo/Operators/Operators.swift
@@ -8,44 +8,44 @@ infix operator <||? { associativity left precedence 150 }
 // MARK: Values
 
 // Pull value from JSON
-public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
+public func <|<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
   return decodeObject(json) >>- { (A.decode <^> $0[key]) ?? .MissingKey(key) }
 }
 
 // Pull optional value from JSON
-public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A?> {
+public func <|?<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A?> {
   return .optional(json <| key)
 }
 
 // Pull embedded value from JSON
-public func <|<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A> {
+public func <|<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A> {
   return flatReduce(keys, json, <|) >>- A.decode
 }
 
 // Pull embedded optional value from JSON
-public func <|?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A?> {
+public func <|?<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A?> {
   return .optional(json <| keys)
 }
 
 // MARK: Arrays
 
 // Pull array from JSON
-public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]> {
+public func <||<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]> {
   return json <| key >>- decodeArray
 }
 
 // Pull optional array from JSON
-public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]?> {
+public func <||?<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]?> {
   return .optional(json <|| key)
 }
 
 // Pull embedded array from JSON
-public func <||<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]> {
+public func <||<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]> {
   return json <| keys >>- decodeArray
 }
 
 // Pull embedded optional array from JSON
-public func <||?<A where A: JSONDecodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]?> {
+public func <||?<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]?> {
   return .optional(json <|| keys)
 }
 

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -28,7 +28,7 @@ public extension JSON {
   }
 }
 
-extension JSON: JSONDecodable {
+extension JSON: Decodable {
   public static func decode(j: JSON) -> Decoded<JSON> {
     return pure(j)
   }

--- a/Argo/Types/JSONDecodable.swift
+++ b/Argo/Types/JSONDecodable.swift
@@ -1,4 +1,4 @@
-public protocol JSONDecodable {
+public protocol Decodable {
   typealias DecodedType = Self
   static func decode(json: JSON) -> Decoded<DecodedType>
 }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Runes
 
-extension String: JSONDecodable {
+extension String: Decodable {
   public static func decode(j: JSON) -> Decoded<String> {
     switch j {
     case let .String(s): return pure(s)
@@ -10,7 +10,7 @@ extension String: JSONDecodable {
   }
 }
 
-extension Int: JSONDecodable {
+extension Int: Decodable {
   public static func decode(j: JSON) -> Decoded<Int> {
     switch j {
     case let .Number(n): return pure(n as Int)
@@ -19,7 +19,7 @@ extension Int: JSONDecodable {
   }
 }
 
-extension Int64: JSONDecodable {
+extension Int64: Decodable {
   public static func decode(j: JSON) -> Decoded<Int64> {
     switch j {
     case let .Number(n): return pure(n.longLongValue)
@@ -28,7 +28,7 @@ extension Int64: JSONDecodable {
   }
 }
 
-extension Double: JSONDecodable {
+extension Double: Decodable {
   public static func decode(j: JSON) -> Decoded<Double> {
     switch j {
     case let .Number(n): return pure(n as Double)
@@ -37,7 +37,7 @@ extension Double: JSONDecodable {
   }
 }
 
-extension Bool: JSONDecodable {
+extension Bool: Decodable {
   public static func decode(j: JSON) -> Decoded<Bool> {
     switch j {
     case let .Number(n): return pure(n as Bool)
@@ -46,7 +46,7 @@ extension Bool: JSONDecodable {
   }
 }
 
-extension Float: JSONDecodable {
+extension Float: Decodable {
   public static func decode(j: JSON) -> Decoded<Float> {
     switch j {
     case let .Number(n): return pure(n as Float)
@@ -55,14 +55,14 @@ extension Float: JSONDecodable {
   }
 }
 
-public func decodeArray<A where A: JSONDecodable, A == A.DecodedType>(value: JSON) -> Decoded<[A]> {
+public func decodeArray<A where A: Decodable, A == A.DecodedType>(value: JSON) -> Decoded<[A]> {
   switch value {
   case let .Array(a): return sequence(A.decode <^> a)
   default: return typeMismatch("Array", value)
   }
 }
 
-public func decodeObject<A where A: JSONDecodable, A == A.DecodedType>(value: JSON) -> Decoded<[String: A]> {
+public func decodeObject<A where A: Decodable, A == A.DecodedType>(value: JSON) -> Decoded<[String: A]> {
   switch value {
   case let .Object(o): return sequence(A.decode <^> o)
   default: return typeMismatch("Object", value)

--- a/ArgoTests/Models/Comment.swift
+++ b/ArgoTests/Models/Comment.swift
@@ -7,7 +7,7 @@ struct Comment {
   let authorName: String
 }
 
-extension Comment: JSONDecodable {
+extension Comment: Decodable {
   static func create(id: Int)(text: String)(authorName: String) -> Comment {
     return Comment(id: id, text: text, authorName: authorName)
   }

--- a/ArgoTests/Models/NSURL.swift
+++ b/ArgoTests/Models/NSURL.swift
@@ -1,7 +1,7 @@
 import Argo
 import Foundation
 
-extension NSURL: JSONDecodable {
+extension NSURL: Decodable {
   public typealias DecodedType = NSURL
 
   public class func decode(j: JSON) -> Decoded<NSURL> {

--- a/ArgoTests/Models/Post.swift
+++ b/ArgoTests/Models/Post.swift
@@ -8,7 +8,7 @@ struct Post {
   let comments: [Comment]
 }
 
-extension Post: JSONDecodable {
+extension Post: Decodable {
   static func create(id: Int)(text: String)(author: User)(comments: [Comment]) -> Post {
     return Post(id: id, text: text, author: author, comments: comments)
   }

--- a/ArgoTests/Models/TestModel.swift
+++ b/ArgoTests/Models/TestModel.swift
@@ -12,7 +12,7 @@ struct TestModel {
   let userOpt: User?
 }
 
-extension TestModel: JSONDecodable {
+extension TestModel: Decodable {
   static func create(numerics: TestModelNumerics)(string: String)(bool: Bool)(stringArray: [String])(stringArrayOpt: [String]?)(eStringArray: [String])(eStringArrayOpt: [String]?)(userOpt: User?) -> TestModel {
     return TestModel(numerics: numerics, string: string, bool: bool, stringArray: stringArray, stringArrayOpt: stringArrayOpt, eStringArray: eStringArray, eStringArrayOpt: eStringArrayOpt, userOpt: userOpt)
   }
@@ -27,7 +27,6 @@ extension TestModel: JSONDecodable {
       <*> j <|| ["embedded", "string_array"]
       <*> j <||? ["embedded", "string_array_opt"]
       <*> j <|? "user_opt"
-
   }
 }
 
@@ -39,11 +38,11 @@ struct TestModelNumerics {
   let intOpt: Int?
 }
 
-extension TestModelNumerics: JSONDecodable {
+extension TestModelNumerics: Decodable {
   static func create(int: Int)(int64: Int64)(double: Double)(float: Float)(intOpt: Int?) -> TestModelNumerics {
     return TestModelNumerics(int: int, int64: int64, double: double, float: float, intOpt: intOpt)
   }
-  
+
   static func decode(j: JSON) -> Decoded<TestModelNumerics> {
     return TestModelNumerics.create
       <^> j <| "int"

--- a/ArgoTests/Models/User.swift
+++ b/ArgoTests/Models/User.swift
@@ -7,7 +7,7 @@ struct User {
   let email: String?
 }
 
-extension User: JSONDecodable {
+extension User: Decodable {
   static func create(id: Int)(name: String)(email: String?) -> User {
     return User(id: id, name: name, email: email)
   }


### PR DESCRIPTION
`Decodable` objects are able to be `decode`d, returning a
`Decoded<DecodedType>`. This is a nice synergy, and leaves us open to
other non-JSON operations in the future.