### PR TITLE
Add a function to convert JSON to .None if = .Null

### DIFF
--- a/Argo/Operators/Operators.swift
+++ b/Argo/Operators/Operators.swift
@@ -9,7 +9,7 @@ infix operator <||? { associativity left precedence 150 }
 
 // Pull value from JSON
 public func <|<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
-  return decodeObject(json) >>- { (A.decode <^> $0[key]) ?? .MissingKey(key) }
+  return decodeObject(json) >>- { (A.decode <^> $0[key] >>- JSON.optional) ?? .MissingKey(key) }
 }
 
 // Pull optional value from JSON

--- a/Argo/Operators/Operators.swift
+++ b/Argo/Operators/Operators.swift
@@ -9,7 +9,7 @@ infix operator <||? { associativity left precedence 150 }
 
 // Pull value from JSON
 public func <|<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
-  return decodeObject(json) >>- { (A.decode <^> $0[key] >>- JSON.optional) ?? .MissingKey(key) }
+  return decodeObject(json) >>- { pure($0[key] ?? .Null) } >>- guardNull(key) >>- A.decode
 }
 
 // Pull optional value from JSON
@@ -49,3 +49,9 @@ public func <||?<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [St
   return .optional(json <|| keys)
 }
 
+private func guardNull(key: String)(j: JSON) -> Decoded<JSON> {
+  switch j {
+  case .Null: return .MissingKey(key)
+  default: return pure(j)
+  }
+}

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -26,6 +26,13 @@ public extension JSON {
     default: return .Null
     }
   }
+
+  static func optional(json: JSON) -> JSON? {
+    switch json {
+    case .Null: return .None
+    default: return json
+    }
+  }
 }
 
 extension JSON: Decodable {

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -26,13 +26,6 @@ public extension JSON {
     default: return .Null
     }
   }
-
-  static func optional(json: JSON) -> JSON? {
-    switch json {
-    case .Null: return .None
-    default: return json
-    }
-  }
 }
 
 extension JSON: Decodable {

--- a/ArgoTests/JSON/types.json
+++ b/ArgoTests/JSON/types.json
@@ -11,6 +11,7 @@
     "hello",
     "world"
   ],
+  "string_array_opt": null,
   "embedded": {
     "string_array": [
       "hello",


### PR DESCRIPTION
With the addition of the `Decoded` type we decided to return a Type
Mismatch whenever the type asked for did not align with the `JSON`. In
the case of Null, we want to assume that it means that the key is just
missing and not of the wrong type. This adds code to convert the `JSON`
into an optional and specifically return `.None` when the `JSON` ==
`.Null`.