### PR TITLE
Add playground

### DIFF
--- a/Argo.playground/Contents.swift
+++ b/Argo.playground/Contents.swift
@@ -1,0 +1,21 @@
+import Argo
+import Runes
+
+struct User {
+    let id: Int
+    let name: String
+    let email: String?
+}
+
+extension User: Decodable  {
+    static func create(id: Int)(name: String)(email: String?) -> User {
+        return User(id: id, name: name, email: email)
+    }
+
+    static func decode(j: JSON) -> Decoded<User> {
+        return create
+            <^> j <| "id"
+            <*> j <| "name"
+            <*> j <|? "email"
+    }
+}

--- a/Argo.playground/Sources/SupportCode.swift
+++ b/Argo.playground/Sources/SupportCode.swift
@@ -1,0 +1,3 @@
+//
+// This file (and all other Swift source files in the Sources directory of this playground) will be precompiled into a framework which is automatically made available to Argo.playground.
+//

--- a/Argo.playground/contents.xcplayground
+++ b/Argo.playground/contents.xcplayground
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx'/>
+<playground version='5.0' target-platform='osx'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Argo.playground/contents.xcplayground
+++ b/Argo.playground/contents.xcplayground
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='osx'/>

--- a/Argo.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Argo.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:../../Code/thoughtbot/Argo/Argo.playground">
+      location = "group:Argo.playground">
    </FileRef>
 </Workspace>

--- a/Argo.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Argo.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../../Code/thoughtbot/Argo/Argo.playground">
+   </FileRef>
+</Workspace>

--- a/Argo.playground/timeline.xctimeline
+++ b/Argo.playground/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/Argo.xcworkspace/contents.xcworkspacedata
+++ b/Argo.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Argo.playground">
+   </FileRef>
+   <FileRef
       location = "group:Argo.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
Now that we're using git submodules (grumble grumble) and a workspace,
we can add a playground to the workspace to act as a scratch
pad/educational document for users.