### PR TITLE
Add whitespace after operator names in operator definitions.

### DIFF
--- a/Argo/Extensions/Dictionary.swift
+++ b/Argo/Extensions/Dictionary.swift
@@ -1,7 +1,7 @@
 import Runes
 
 // pure merge for Dictionaries
-func +<T, V>(var lhs: [T: V], rhs: [T: V]) -> [T: V] {
+func + <T, V>(var lhs: [T: V], rhs: [T: V]) -> [T: V] {
   for (key, val) in rhs {
     lhs[key] = val
   }
@@ -15,6 +15,6 @@ extension Dictionary {
   }
 }
 
-func <^><A, B, C>(f: A -> B, a: [C: A]) -> [C: B] {
+func <^> <A, B, C>(f: A -> B, a: [C: A]) -> [C: B] {
   return a.map(f)
 }

--- a/Argo/Operators/Operators.swift
+++ b/Argo/Operators/Operators.swift
@@ -8,43 +8,44 @@ infix operator <||? { associativity left precedence 150 }
 // MARK: Values
 
 // Pull value from JSON
-public func <|<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
+public func <| <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
   return decodedJSONForKey(json, key) >>- A.decode
 }
 
 // Pull optional value from JSON
-public func <|?<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A?> {
+public func <|? <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A?> {
   return .optional(json <| key)
 }
 
 // Pull embedded value from JSON
-public func <|<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A> {
+public func <| <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A> {
   return flatReduce(keys, json, decodedJSONForKey) >>- A.decode
 }
 
 // Pull embedded optional value from JSON
-public func <|?<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A?> {
+public func <|? <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<A?> {
   return .optional(json <| keys)
 }
 
 // MARK: Arrays
 
 // Pull array from JSON
-public func <||<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]> {
+public func <|| <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]> {
   return json <| key >>- decodeArray
 }
 
 // Pull optional array from JSON
-public func <||?<A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]?> {
+public func <||? <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[A]?> {
   return .optional(json <|| key)
 }
 
 // Pull embedded array from JSON
-public func <||<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]> {
+public func <|| <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]> {
   return json <| keys >>- decodeArray
 }
 
 // Pull embedded optional array from JSON
-public func <||?<A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]?> {
+public func <||? <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[A]?> {
   return .optional(json <|| keys)
 }
+

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -73,14 +73,14 @@ public func pure<A>(a: A) -> Decoded<A> {
 
 // MARK: Monadic Operators
 
-public func >>-<A, B>(a: Decoded<A>, f: A -> Decoded<B>) -> Decoded<B> {
+public func >>- <A, B>(a: Decoded<A>, f: A -> Decoded<B>) -> Decoded<B> {
   return a.flatMap(f)
 }
 
-public func <^><A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
+public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
   return a.map(f)
 }
 
-public func <*><A, B>(f: Decoded<A -> B>, a: Decoded<A>) -> Decoded<B> {
+public func <*> <A, B>(f: Decoded<A -> B>, a: Decoded<A>) -> Decoded<B> {
   return a.apply(f)
 }

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -48,7 +48,7 @@ extension JSON: Printable {
 
 extension JSON: Equatable { }
 
-public func ==(lhs: JSON, rhs: JSON) -> Bool {
+public func == (lhs: JSON, rhs: JSON) -> Bool {
   switch (lhs, rhs) {
   case let (.String(l), .String(r)): return l == r
   case let (.Number(l), .Number(r)): return l == r


### PR DESCRIPTION
Previously, all our operator definitions looked like `func ***<T>(args)` or `func ***(args)`. For many operator names, having it butt up directly against a `<` or `(` is somewhat ugly, even though it's syntactically OK. This PR changes all of those to include a space. This style has been previously established in places like ReactiveCocoa, Box, and Apple's own documentation.