### PR TITLE
Refactored `JSONFileReader` as a free function

### DIFF
--- a/ArgoTests/JSON/JSONFileReader.swift
+++ b/ArgoTests/JSON/JSONFileReader.swift
@@ -1,15 +1,10 @@
 import Foundation
+import Runes
 
-class JSONFileReader {
-  class func JSON(fromFile file: String) -> AnyObject? {
-    let path = NSBundle(forClass: self).pathForResource(file, ofType: "json")
-
-    if path != nil {
-      if let data = NSData(contentsOfFile: path!) {
-        return NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(0), error: nil)
-      }
-    }
-
-    return .None
-  }
+func JSONFromFile(file: String) -> AnyObject? {
+  return NSBundle(forClass: JSONFileReader.self).pathForResource(file, ofType: "json")
+    >>- { NSData(contentsOfFile: $0) }
+    >>- { NSJSONSerialization.JSONObjectWithData($0, options: NSJSONReadingOptions(0), error: nil) }
 }
+
+private class JSONFileReader { }

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -4,7 +4,7 @@ import Box
 
 class DecodedTests: XCTestCase {
   func testDecodedSuccess() {
-    let user: Decoded<User> = decode(JSONFileReader.JSON(fromFile: "user_with_email")!)
+    let user: Decoded<User> = decode(JSONFromFile("user_with_email")!)
 
     switch user {
     case let .Success(x): XCTAssert(user.description == "Success(\(x))")
@@ -13,7 +13,7 @@ class DecodedTests: XCTestCase {
   }
 
   func testDecodedTypeMissmatch() {
-    let user: Decoded<User> = decode(JSONFileReader.JSON(fromFile: "user_with_bad_type")!)
+    let user: Decoded<User> = decode(JSONFromFile("user_with_bad_type")!)
 
     switch user {
     case let .TypeMismatch(s): XCTAssert(user.description == "TypeMismatch(\(s))")
@@ -22,7 +22,7 @@ class DecodedTests: XCTestCase {
   }
 
   func testDecodedMissingKey() {
-    let user: Decoded<User> = decode(JSONFileReader.JSON(fromFile: "user_without_key")!)
+    let user: Decoded<User> = decode(JSONFromFile("user_without_key")!)
 
     switch user {
     case let .MissingKey(s): XCTAssert(user.description == "MissingKey(\(s))")

--- a/ArgoTests/Tests/EmbeddedJSONDecodingTests.swift
+++ b/ArgoTests/Tests/EmbeddedJSONDecodingTests.swift
@@ -4,7 +4,7 @@ import Runes
 
 class EmbeddedJSONDecodingTests: XCTestCase {
   func testCommentDecodingWithEmbeddedUserName() {
-    let comment: Comment? = JSONFileReader.JSON(fromFile: "comment") >>- decode
+    let comment: Comment? = JSONFromFile("comment") >>- decode
 
     XCTAssert(comment != nil)
     XCTAssert(comment?.id == 6)
@@ -13,7 +13,7 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithEmbeddedUserModel() {
-    let post: Post? = JSONFileReader.JSON(fromFile: "post_no_comments") >>- decode
+    let post: Post? = JSONFromFile("post_no_comments") >>- decode
 
     XCTAssert(post != nil)
     XCTAssert(post?.id == 3)
@@ -23,7 +23,7 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithEmbeddedUserModelAndComments() {
-    let post: Post? = JSONFileReader.JSON(fromFile: "post_comments") >>- decode
+    let post: Post? = JSONFromFile("post_comments") >>- decode
 
     XCTAssert(post != nil)
     XCTAssert(post?.id == 3)
@@ -33,7 +33,7 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithBadComments() {
-    let post: Post? = JSONFileReader.JSON(fromFile: "post_bad_comments") >>- decode
+    let post: Post? = JSONFromFile("post_bad_comments") >>- decode
 
     XCTAssert(post == nil)
   }

--- a/ArgoTests/Tests/EquatableTests.swift
+++ b/ArgoTests/Tests/EquatableTests.swift
@@ -4,15 +4,15 @@ import Runes
 
 class EquatableTests: XCTestCase {
   func testEqualJSONObjects() {
-    let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "types")
-    let anotherParsed = JSON.parse <^> JSONFileReader.JSON(fromFile: "types")
+    let json = JSON.parse <^> JSONFromFile("types")
+    let anotherParsed = JSON.parse <^> JSONFromFile("types")
 
     XCTAssertEqual(json!, anotherParsed!)
   }
 
   func testNotEqualJSONObjects() {
-    let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "types")
-    let anotherJSON = JSON.parse <^> JSONFileReader.JSON(fromFile: "types_fail_embedded")
+    let json = JSON.parse <^> JSONFromFile("types")
+    let anotherJSON = JSON.parse <^> JSONFromFile("types_fail_embedded")
 
     XCTAssertNotEqual(json!, anotherJSON!)
   }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -4,14 +4,14 @@ import Runes
 
 class ExampleTests: XCTestCase {
   func testJSONWithRootArray() {
-    let stringArray: [String]? = JSONFileReader.JSON(fromFile: "array_root") >>- decode
+    let stringArray: [String]? = JSONFromFile("array_root") >>- decode
 
     XCTAssertNotNil(stringArray)
     XCTAssertEqual(stringArray!, ["foo", "bar", "baz"])
   }
 
   func testJSONWithRootObject() {
-    let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "root_object")
+    let json = JSON.parse <^> JSONFromFile("root_object")
     let user: User? = json >>- { ($0 <| "user").value }
 
     XCTAssert(user != nil)
@@ -22,7 +22,7 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingNonFinalClass() {
-    let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "url")
+    let json = JSON.parse <^> JSONFromFile("url")
     let url: NSURL? = json >>- { ($0 <| "url").value }
 
     XCTAssert(url != nil)
@@ -31,13 +31,13 @@ class ExampleTests: XCTestCase {
 
   func testDecodingJSONWithRootArray() {
     let expected = JSON.parse([["title": "Foo", "age": 21], ["title": "Bar", "age": 32]])
-    let json = JSON.parse <^> JSONFileReader.JSON(fromFile: "root_array")
+    let json = JSON.parse <^> JSONFromFile("root_array")
 
     XCTAssert(.Some(expected) == json)
   }
 
   func testFlatMapOptionals() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "user_with_email")
+    let json: AnyObject? = JSONFromFile("user_with_email")
     let user: User? = json >>- decode
 
     XCTAssert(user?.id == 1)
@@ -46,7 +46,7 @@ class ExampleTests: XCTestCase {
   }
 
   func testFlatMapDecoded() {
-    let json: AnyObject? = JSONFileReader.JSON(fromFile: "user_with_email")
+    let json: AnyObject? = JSONFromFile("user_with_email")
     let user: Decoded<User> = .fromOptional(json) >>- decode
 
     XCTAssert(user.value?.id == 1)

--- a/ArgoTests/Tests/OptionalPropertyDecodingTests.swift
+++ b/ArgoTests/Tests/OptionalPropertyDecodingTests.swift
@@ -4,7 +4,7 @@ import Runes
 
 class OptionalPropertyDecodingTests: XCTestCase {
   func testUserDecodingWithEmail() {
-    let user: User? = JSONFileReader.JSON(fromFile: "user_with_email") >>- decode
+    let user: User? = JSONFromFile("user_with_email") >>- decode
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -14,7 +14,7 @@ class OptionalPropertyDecodingTests: XCTestCase {
   }
 
   func testUserDecodingWithoutEmail() {
-    let user: User? = JSONFileReader.JSON(fromFile: "user_without_email") >>- decode
+    let user: User? = JSONFromFile("user_without_email") >>- decode
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -4,7 +4,7 @@ import Runes
 
 class PerformanceTests: XCTestCase {
   func testParsePerformance() {
-    let json: AnyObject = JSONFileReader.JSON(fromFile: "big_data")!
+    let json: AnyObject = JSONFromFile("big_data")!
 
     measureBlock {
       let j = JSON.parse(json)
@@ -12,7 +12,7 @@ class PerformanceTests: XCTestCase {
   }
 
   func testDecodePerformance() {
-    let json: AnyObject = JSONFileReader.JSON(fromFile: "big_data")!
+    let json: AnyObject = JSONFromFile("big_data")!
     let j = JSON.parse(json)
 
     measureBlock {

--- a/ArgoTests/Tests/TypeTests.swift
+++ b/ArgoTests/Tests/TypeTests.swift
@@ -4,7 +4,7 @@ import Runes
 
 class TypeTests: XCTestCase {
   func testAllTheTypes() {
-    let model: TestModel? = JSONFileReader.JSON(fromFile: "types") >>- decode
+    let model: TestModel? = JSONFromFile("types") >>- decode
 
     XCTAssert(model != nil)
     XCTAssert(model?.numerics.int == 5)
@@ -25,7 +25,7 @@ class TypeTests: XCTestCase {
   }
 
   func testFailingEmbedded() {
-    let model: TestModel? = JSONFileReader.JSON(fromFile: "types_fail_embedded") >>- decode
+    let model: TestModel? = JSONFromFile("types_fail_embedded") >>- decode
 
     XCTAssert(model == nil)
   }


### PR DESCRIPTION
I thought it might be worthwhile to reduce the code involved in reading JSON from file in the test cases, as it's an operation that is performed many times.

From: `JSONFileReader.JSON(fromFile: "jsonFile")`
To: `JSONFromFile("jsonFile")`

To achieve this I've done something slightly sneaky to enable `NSBundle(forClass:…)` to still work. I've created a `private class JSONFileReader { }` to pass to `NSBundle`. What are your thoughts on this?