### PR TITLE
Swift 2.0 - Remove Box from .gitmodules and minor cleanup related to Box, update Runes 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Carthage/Checkouts/Box"]
-	path = Carthage/Checkouts/Box
-	url = https://github.com/robrix/Box.git
 [submodule "Carthage/Checkouts/Runes"]
 	path = Carthage/Checkouts/Runes
 	url = https://github.com/thoughtbot/Runes.git

--- a/Argo.podspec
+++ b/Argo.podspec
@@ -17,6 +17,5 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.9'
 
   spec.dependency 'Runes', '>= 1.2.2'
-  spec.dependency 'Box', '~> 1.2'
 end
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "thoughtbot/Runes" >= 1.2.2
+github "thoughtbot/Runes" "swift-2.0"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ for up to date installation instructions.
 
 [carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
 
-You'll also need to add `Runes.framework` and `Box.framework` to your Xcode
+You'll also need to add `Runes.framework` to your Xcode
 project.
 
 [Runes]: https://github.com/thoughtbot/runes
-[Box]: https://github.com/robrix/box
 
 ### [CocoaPods]
 
@@ -61,7 +60,7 @@ I guess you could do it this way if that's your thing.
 Add this repo as a submodule, and add the project file to your workspace. You
 can then link against `Argo.framework` for your application target.
 
-You'll also need to add [Runes] and [Box] to your project the same way.
+You'll also need to add [Runes] to your project the same way.
 
 ## Usage tl;dr:
 


### PR DESCRIPTION
Box submodule entry was still present inside .gitmodules cause the following error

```
*** Checking out Argo at "651568ba61b58fa9112746a887e2887afd39a205"
Parse error: expected submodule commit SHA in ls-tree output: 
```

also cleaned up Box references form README and updated podspec (untested)
and update Runes to use latest Swift 2.0 branch in order to avoid the following error msg:

```
<unknown>:0: error: module file was created by an older version of the compiler: /Users/anthonymittaz/Projects/Marketplacer/YauShop/Carthage/Build/iOS/Runes.framework/Modules/Runes.swiftmodule/x86_64.swiftmodule
```
