### PR TITLE
Update Cartfile to use version 1.2.2 or newer of Box.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "thoughtbot/Runes" >= 1.2.2
-github "robrix/Box" ~> 1.2.0
+github "robrix/Box" >= 1.2.2


### PR DESCRIPTION
Set the version of Box to be 1.2.2 or greater in the Cartfile. 