### PR TITLE
Make sequence public

### DIFF
--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -1,12 +1,12 @@
 import Runes
 
-func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
+public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
   return reduce(xs, pure([])) { accum, elem in
     curry(+) <^> accum <*> (pure <^> elem)
   }
 }
 
-func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
+public func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
   return reduce(xs, pure([:])) { accum, elem in
     curry(+) <^> accum <*> ({ [elem.0: $0] } <^> elem.1)
   }


### PR DESCRIPTION
This is a really useful function for decoding more complex types like
multi-dimensional arrays. We should open it up to users of Argo.