### PR TITLE
Remove Runes as an external dependency

### DIFF
--- a/Argo Playground.playground/Pages/Basics.xcplaygroundpage/Contents.swift
+++ b/Argo Playground.playground/Pages/Basics.xcplaygroundpage/Contents.swift
@@ -5,15 +5,14 @@
 */
 import Foundation
 import Argo
-import Runes
 import Curry
 /*:
 **Helper function** – load JSON from a file
 */
 func JSONFromFile(file: String) -> AnyObject? {
   return NSBundle.mainBundle().pathForResource(file, ofType: "json")
-    >>- { NSData(contentsOfFile: $0) }
-    >>- JSONObjectWithData
+    .flatMap { NSData(contentsOfFile: $0) }
+    .flatMap(JSONObjectWithData)
 }
 
 func JSONObjectWithData(data: NSData) -> AnyObject? {
@@ -50,6 +49,6 @@ extension User: Decodable  {
 /*:
 * * *
 */
-let user: User? = JSONFromFile("user_with_email") >>- decode
+let user: User? = JSONFromFile("user_with_email").flatMap(decode)
 print(user!)
 

--- a/Argo Playground.playground/Pages/iTunes Example.xcplaygroundpage/Contents.swift
+++ b/Argo Playground.playground/Pages/iTunes Example.xcplaygroundpage/Contents.swift
@@ -5,15 +5,14 @@
 */
 import Foundation
 import Argo
-import Runes
 import Curry
 /*:
 **Helper function** – load JSON from a file
 */
 func JSONFromFile(file: String) -> AnyObject? {
   return NSBundle.mainBundle().pathForResource(file, ofType: "json")
-    >>- { NSData(contentsOfFile: $0) }
-    >>- JSONObjectWithData
+    .flatMap { NSData(contentsOfFile: $0) }
+    .flatMap(JSONObjectWithData)
 }
 
 func JSONObjectWithData(data: NSData) -> AnyObject? {
@@ -63,6 +62,6 @@ extension App: Decodable  {
 /*:
 * * *
 */
-let app: App? = (JSONFromFile("tropos")?["results"] >>- decode)?.first
+let app: App? = (JSONFromFile("tropos")?["results"].flatMap(decode))?.first
 print(app!)
 

--- a/Argo.podspec
+++ b/Argo.podspec
@@ -10,12 +10,10 @@ Pod::Spec.new do |spec|
     'thoughtbot' => nil,
   }
   spec.social_media_url = 'http://twitter.com/thoughtbot'
-  spec.source = { :git => 'https://github.com/thoughtbot/Argo.git', :tag => "v#{spec.version}" }
-  spec.source_files = 'Argo/**/*.{h,swift}'
+  spec.source = { :git => 'https://github.com/thoughtbot/Argo.git', :tag => "v#{spec.version}", :submodules => true }
+  spec.source_files = 'Argo/**/*.{h,swift}', 'Carthage/Checkouts/Runes/Source/Runes.swift'
   spec.requires_arc = true
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
-
-  spec.dependency 'Runes', '>= 1.2.2'
 end
 

--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -65,9 +65,9 @@
 		F862E0AE1A519D5C0093B028 /* types_fail_embedded.json in Resources */ = {isa = PBXBuildFile; fileRef = EA4EAF7219DD96330036AE0D /* types_fail_embedded.json */; };
 		F874B7EA1A66BF52004CCE5E /* root_array.json in Resources */ = {isa = PBXBuildFile; fileRef = F874B7E91A66BF52004CCE5E /* root_array.json */; };
 		F874B7EB1A66C221004CCE5E /* root_array.json in Resources */ = {isa = PBXBuildFile; fileRef = F874B7E91A66BF52004CCE5E /* root_array.json */; };
+		F876F1D71B56FBB300B38589 /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F876F1D61B56FBB300B38589 /* Runes.swift */; };
+		F876F1D81B56FBB300B38589 /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F876F1D61B56FBB300B38589 /* Runes.swift */; };
 		F87897EF1A927864009316A5 /* Argo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAD9FACF19D0EAB50031E006 /* Argo.framework */; };
-		F87AD8B61AF7DFC500D6E3FF /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87AD8B41AF7DFC500D6E3FF /* Runes.framework */; };
-		F87AD8BA1AF7DFCD00D6E3FF /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87AD8B81AF7DFCD00D6E3FF /* Runes.framework */; };
 		F87EB6A21ABC5F1300E3B0AB /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EB6991ABC5F1300E3B0AB /* curry.swift */; };
 		F87EB6A31ABC5F1300E3B0AB /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EB6991ABC5F1300E3B0AB /* curry.swift */; };
 		F87EB6A41ABC5F1300E3B0AB /* decode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87EB69A1ABC5F1300E3B0AB /* decode.swift */; };
@@ -202,8 +202,7 @@
 		F84290281B57EFAE008F57B4 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Curry.framework; path = "Carthage/Checkouts/Curry/build/Debug-iphoneos/Curry.framework"; sourceTree = "<group>"; };
 		F842902A1B57EFB5008F57B4 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Curry.framework; path = Carthage/Checkouts/Curry/build/Debug/Curry.framework; sourceTree = "<group>"; };
 		F874B7E91A66BF52004CCE5E /* root_array.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = root_array.json; sourceTree = "<group>"; };
-		F87AD8B41AF7DFC500D6E3FF /* Runes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Runes.framework; path = "Carthage/Checkouts/runes/build/Debug-iphoneos/Runes.framework"; sourceTree = "<group>"; };
-		F87AD8B81AF7DFCD00D6E3FF /* Runes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Runes.framework; path = Carthage/Checkouts/runes/build/Debug/Runes.framework; sourceTree = "<group>"; };
+		F876F1D61B56FBB300B38589 /* Runes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Runes.swift; path = Carthage/Checkouts/Runes/Source/Runes.swift; sourceTree = SOURCE_ROOT; };
 		F87EB6991ABC5F1300E3B0AB /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = curry.swift; sourceTree = "<group>"; };
 		F87EB69A1ABC5F1300E3B0AB /* decode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = decode.swift; sourceTree = "<group>"; };
 		F87EB69B1ABC5F1300E3B0AB /* flatReduce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = flatReduce.swift; sourceTree = "<group>"; };
@@ -224,7 +223,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F87AD8B61AF7DFC500D6E3FF /* Runes.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,7 +239,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F87AD8BA1AF7DFCD00D6E3FF /* Runes.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +333,7 @@
 		EAD9FAE919D0F6480031E006 /* Operators */ = {
 			isa = PBXGroup;
 			children = (
+				F876F1D61B56FBB300B38589 /* Runes.swift */,
 				EAD9FAF519D0F7900031E006 /* Operators.swift */,
 			);
 			path = Operators;
@@ -408,7 +406,6 @@
 		F87AD8BC1AF7E04500D6E3FF /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				F87AD8B41AF7DFC500D6E3FF /* Runes.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -416,7 +413,6 @@
 		F87AD8BD1AF7E04B00D6E3FF /* Mac */ = {
 			isa = PBXGroup;
 			children = (
-				F87AD8B81AF7DFCD00D6E3FF /* Runes.framework */,
 			);
 			name = Mac;
 			sourceTree = "<group>";
@@ -689,6 +685,7 @@
 				F87EB6AC1ABC5F1300E3B0AB /* JSON.swift in Sources */,
 				F87EB6A61ABC5F1300E3B0AB /* flatReduce.swift in Sources */,
 				F87EB6A81ABC5F1300E3B0AB /* sequence.swift in Sources */,
+				F876F1D71B56FBB300B38589 /* Runes.swift in Sources */,
 				F8CBE6671A64521000316FBC /* Dictionary.swift in Sources */,
 				EAD9FAF619D0F7900031E006 /* Operators.swift in Sources */,
 				F87EB6B01ABC5F1300E3B0AB /* StandardTypes.swift in Sources */,
@@ -729,6 +726,7 @@
 				F87EB6AD1ABC5F1300E3B0AB /* JSON.swift in Sources */,
 				F87EB6A71ABC5F1300E3B0AB /* flatReduce.swift in Sources */,
 				F87EB6A91ABC5F1300E3B0AB /* sequence.swift in Sources */,
+				F876F1D81B56FBB300B38589 /* Runes.swift in Sources */,
 				F8CBE6681A64526300316FBC /* Dictionary.swift in Sources */,
 				F89335761A4CE93600B88685 /* Operators.swift in Sources */,
 				F87EB6B11ABC5F1300E3B0AB /* StandardTypes.swift in Sources */,

--- a/Argo.xcworkspace/contents.xcworkspacedata
+++ b/Argo.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,6 @@
       location = "group:Argo.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage/Checkouts/Runes/Runes.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Carthage/Checkouts/Curry/Curry.xcodeproj">
    </FileRef>
    <FileRef

--- a/Argo/Extensions/Dictionary.swift
+++ b/Argo/Extensions/Dictionary.swift
@@ -1,5 +1,3 @@
-import Runes
-
 // pure merge for Dictionaries
 func + <T, V>(var lhs: [T: V], rhs: [T: V]) -> [T: V] {
   for (key, val) in rhs {

--- a/Argo/Functions/flatReduce.swift
+++ b/Argo/Functions/flatReduce.swift
@@ -1,5 +1,3 @@
-import Runes
-
 func flatReduce<S: SequenceType, U>(sequence: S, initial: U, combine: (U, S.Generator.Element) -> Decoded<U>) -> Decoded<U> {
   return sequence.reduce(pure(initial)) { accum, x in
     accum >>- { combine($0, x) }

--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -1,8 +1,6 @@
-import Runes
-
 func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
   return xs.reduce(pure([])) { accum, elem in
-    curry(+) <^> accum <*> (pure <^> elem)
+    curry(+) <^> accum <*> ({ [$0] } <^> elem)
   }
 }
 

--- a/Argo/Operators/Operators.swift
+++ b/Argo/Operators/Operators.swift
@@ -1,5 +1,3 @@
-import Runes
-
 infix operator <| { associativity left precedence 150 }
 infix operator <|? { associativity left precedence 150 }
 infix operator <|| { associativity left precedence 150 }

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -1,5 +1,3 @@
-import Runes
-
 public enum Decoded<T> {
   case Success(T)
   case TypeMismatch(String)

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Runes
 
 public enum JSON {
   case Object([Swift.String: JSON])
@@ -16,8 +15,7 @@ public extension JSON {
 
     case let v as [Swift.String: AnyObject]:
       return .Object(v.reduce([:]) { (var accum, elem) in
-        let parsedValue = (self.parse <^> elem.1) ?? .Null
-        accum[elem.0] = parsedValue
+        accum[elem.0] = parse(elem.1)
         return accum
       })
 

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Runes
 
 extension String: Decodable {
   public static func decode(j: JSON) -> Decoded<String> {
@@ -64,7 +63,7 @@ public extension Optional where T: Decodable, T == T.DecodedType {
 public extension Array where Element: Decodable, Element == Element.DecodedType {
   static func decode(j: JSON) -> Decoded<[Element]> {
     switch j {
-    case let .Array(a): return sequence(Element.decode <^> a)
+    case let .Array(a): return sequence(a.map(Element.decode))
     default: return typeMismatch("Array", forObject: j)
     }
   }

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "thoughtbot/Runes" "swift-2.0"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,2 @@
 github "thoughtbot/Curry"
+github "thoughtbot/Runes" "v3.0.0-rc.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "thoughtbot/Runes" "674d76eb15eda4bc95fbbd15b3c96a6d15774754"
+github "thoughtbot/Runes" "5708b06f24fb3e4371ff7c15be8c07256a9bc389"
 github "thoughtbot/Curry" "v1.0.0"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ for up to date installation instructions.
 
 [carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
 
-You'll also need to add `Runes.framework` to your Xcode
-project.
-
-[Runes]: https://github.com/thoughtbot/runes
-
 ### [CocoaPods]
 
 [CocoaPods]: http://cocoapods.org
@@ -60,13 +55,10 @@ I guess you could do it this way if that's your thing.
 Add this repo as a submodule, and add the project file to your workspace. You
 can then link against `Argo.framework` for your application target.
 
-You'll also need to add [Runes] to your project the same way.
-
 ## Usage tl;dr:
 
 ```swift
 import Argo
-import Runes
 import Curry
 
 struct User {


### PR DESCRIPTION
This removes Runes as an external dependency, preferring to use it as an
internal dependency that only serves to define the operators for map,
apply, and flatMap.

The benefit here is that for users of Argo, they can simply import Argo
in their models instead of needing to import Argo _and_ Runes. But at
the same time, we can still rely on Runes to provide a centralized place
for the definition of the map, apply, and flatMap operators. This means
Argo will still play nice with Runes, or other libs that use the same
version of Runes to define these operators.

Internally, we weren't using much of Runes anyway, and the parts we
_were_ using can be implemented as instance methods instead. Note,
especially, how simple the transition from `>>-` to `.flatMap` is.