### PR TITLE
Remove Runes references from tests + cleanup

### DIFF
--- a/ArgoTests/JSON/JSONFileReader.swift
+++ b/ArgoTests/JSON/JSONFileReader.swift
@@ -1,10 +1,9 @@
 import Foundation
-import Runes
 
 func JSONFromFile(file: String) -> AnyObject? {
   return NSBundle(forClass: JSONFileReader.self).pathForResource(file, ofType: "json")
-    >>- { NSData(contentsOfFile: $0) }
-    >>- JSONObjectWithData
+    .flatMap { NSData(contentsOfFile: $0) }
+    .flatMap(JSONObjectWithData)
 }
 
 private func JSONObjectWithData(data: NSData) -> AnyObject? {

--- a/ArgoTests/Models/Comment.swift
+++ b/ArgoTests/Models/Comment.swift
@@ -1,5 +1,4 @@
 import Argo
-import Runes
 import Curry
 
 struct Comment {

--- a/ArgoTests/Models/Comment.swift
+++ b/ArgoTests/Models/Comment.swift
@@ -9,7 +9,7 @@ struct Comment {
 
 extension Comment: Decodable {
   static func decode(j: JSON) -> Decoded<Comment> {
-    return curry(Comment.init)
+    return curry(self.init)
       <^> j <| "id"
       <*> j <| "text"
       <*> j <| ["author", "name"]

--- a/ArgoTests/Models/Post.swift
+++ b/ArgoTests/Models/Post.swift
@@ -10,7 +10,7 @@ struct Post {
 
 extension Post: Decodable {
   static func decode(j: JSON) -> Decoded<Post> {
-    return curry(Post.init)
+    return curry(self.init)
       <^> j <| "id"
       <*> j <| "text"
       <*> j <| "author"

--- a/ArgoTests/Models/Post.swift
+++ b/ArgoTests/Models/Post.swift
@@ -1,5 +1,4 @@
 import Argo
-import Runes
 import Curry
 
 struct Post {

--- a/ArgoTests/Models/TestModel.swift
+++ b/ArgoTests/Models/TestModel.swift
@@ -1,5 +1,4 @@
 import Argo
-import Runes
 import Curry
 
 struct TestModel {

--- a/ArgoTests/Models/TestModel.swift
+++ b/ArgoTests/Models/TestModel.swift
@@ -14,13 +14,11 @@ struct TestModel {
 
 extension TestModel: Decodable {
   static func decode(j: JSON) -> Decoded<TestModel> {
-//    let a = curry(TestModel.init)
-    return curry(TestModel.init)
+    return curry(self.init)
       <^> j <| "numerics"
       <*> j <| ["user_opt", "name"]
       <*> j <| "bool"
       <*> j <|| "string_array"
-//    return a
       <*> j <||? "string_array_opt"
       <*> j <|| ["embedded", "string_array"]
       <*> j <||? ["embedded", "string_array_opt"]
@@ -38,12 +36,10 @@ struct TestModelNumerics {
 
 extension TestModelNumerics: Decodable {
   static func decode(j: JSON) -> Decoded<TestModelNumerics> {
-//    let a = curry(TestModelNumerics.init)
-    return curry(TestModelNumerics.init)
+    return curry(self.init)
       <^> j <| "int"
       <*> j <| "int64"
       <*> j <| "double"
-//    return a
       <*> j <| "float"
       <*> j <|? "int_opt"
   }

--- a/ArgoTests/Models/User.swift
+++ b/ArgoTests/Models/User.swift
@@ -9,7 +9,7 @@ struct User {
 
 extension User: Decodable {
   static func decode(j: JSON) -> Decoded<User> {
-    return curry(User.init)
+    return curry(self.init)
       <^> j <| "id"
       <*> j <| ["userinfo", "name"] <|> j <| "name"
       <*> j <|? "email"

--- a/ArgoTests/Models/User.swift
+++ b/ArgoTests/Models/User.swift
@@ -1,5 +1,4 @@
 import Argo
-import Runes
 import Curry
 
 struct User {

--- a/ArgoTests/Tests/EmbeddedJSONDecodingTests.swift
+++ b/ArgoTests/Tests/EmbeddedJSONDecodingTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 import Argo
-import Runes
 
 class EmbeddedJSONDecodingTests: XCTestCase {
   func testCommentDecodingWithEmbeddedUserName() {
-    let comment: Comment? = JSONFromFile("comment") >>- decode
+    let comment: Comment? = JSONFromFile("comment").flatMap(decode)
 
     XCTAssert(comment != nil)
     XCTAssert(comment?.id == 6)
@@ -13,7 +12,7 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithEmbeddedUserModel() {
-    let post: Post? = JSONFromFile("post_no_comments") >>- decode
+    let post: Post? = JSONFromFile("post_no_comments").flatMap(decode)
 
     XCTAssert(post != nil)
     XCTAssert(post?.id == 3)
@@ -23,7 +22,7 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithEmbeddedUserModelAndComments() {
-    let post: Post? = JSONFromFile("post_comments") >>- decode
+    let post: Post? = JSONFromFile("post_comments").flatMap(decode)
 
     XCTAssert(post != nil)
     XCTAssert(post?.id == 3)
@@ -33,7 +32,7 @@ class EmbeddedJSONDecodingTests: XCTestCase {
   }
 
   func testPostDecodingWithBadComments() {
-    let post: Post? = JSONFromFile("post_bad_comments") >>- decode
+    let post: Post? = JSONFromFile("post_bad_comments").flatMap(decode)
 
     XCTAssert(post == nil)
   }

--- a/ArgoTests/Tests/EquatableTests.swift
+++ b/ArgoTests/Tests/EquatableTests.swift
@@ -1,18 +1,17 @@
 import XCTest
 import Argo
-import Runes
 
 class EquatableTests: XCTestCase {
   func testEqualJSONObjects() {
-    let json = JSON.parse <^> JSONFromFile("types")
-    let anotherParsed = JSON.parse <^> JSONFromFile("types")
+    let json = JSONFromFile("types").map(JSON.parse)
+    let anotherParsed = JSONFromFile("types").map(JSON.parse)
 
     XCTAssertEqual(json!, anotherParsed!)
   }
 
   func testNotEqualJSONObjects() {
-    let json = JSON.parse <^> JSONFromFile("types")
-    let anotherJSON = JSON.parse <^> JSONFromFile("types_fail_embedded")
+    let json = JSONFromFile("types").map(JSON.parse)
+    let anotherJSON = JSONFromFile("types_fail_embedded").map(JSON.parse)
 
     XCTAssertNotEqual(json!, anotherJSON!)
   }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -1,18 +1,17 @@
 import XCTest
 import Argo
-import Runes
 
 class ExampleTests: XCTestCase {
   func testJSONWithRootArray() {
-    let stringArray: [String]? = JSONFromFile("array_root") >>- decode
+    let stringArray: [String]? = JSONFromFile("array_root").flatMap(decode)
 
     XCTAssertNotNil(stringArray)
     XCTAssertEqual(stringArray!, ["foo", "bar", "baz"])
   }
 
   func testJSONWithRootObject() {
-    let json = JSON.parse <^> JSONFromFile("root_object")
-    let user: User? = json >>- { ($0 <| "user").value }
+    let json = JSONFromFile("root_object").map(JSON.parse)
+    let user: User? = json.flatMap { ($0 <| "user").value }
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -22,8 +21,8 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingNonFinalClass() {
-    let json = JSON.parse <^> JSONFromFile("url")
-    let url: NSURL? = json >>- { ($0 <| "url").value }
+    let json = JSONFromFile("url").map(JSON.parse)
+    let url: NSURL? = json.flatMap { ($0 <| "url").value }
 
     XCTAssert(url != nil)
     XCTAssert(url?.absoluteString == "http://example.com")
@@ -31,14 +30,14 @@ class ExampleTests: XCTestCase {
 
   func testDecodingJSONWithRootArray() {
     let expected = JSON.parse([["title": "Foo", "age": 21], ["title": "Bar", "age": 32]])
-    let json = JSON.parse <^> JSONFromFile("root_array")
+    let json = JSONFromFile("root_array").map(JSON.parse)
 
     XCTAssert(.Some(expected) == json)
   }
 
   func testFlatMapOptionals() {
     let json: AnyObject? = JSONFromFile("user_with_email")
-    let user: User? = json >>- decode
+    let user: User? = json.flatMap(decode)
 
     XCTAssert(user?.id == 1)
     XCTAssert(user?.name == "Cool User")
@@ -47,7 +46,7 @@ class ExampleTests: XCTestCase {
   
   func testNilCoalescing() {
     let json: AnyObject? = JSONFromFile("user_with_nested_name")
-    let user: User? = json >>- decode
+    let user: User? = json.flatMap(decode)
 
     XCTAssert(user?.id == 1)
     XCTAssert(user?.name == "Very Cool User")

--- a/ArgoTests/Tests/OptionalPropertyDecodingTests.swift
+++ b/ArgoTests/Tests/OptionalPropertyDecodingTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 import Argo
-import Runes
 
 class OptionalPropertyDecodingTests: XCTestCase {
   func testUserDecodingWithEmail() {
-    let user: User? = JSONFromFile("user_with_email") >>- decode
+    let user: User? = JSONFromFile("user_with_email").flatMap(decode)
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -14,7 +13,7 @@ class OptionalPropertyDecodingTests: XCTestCase {
   }
 
   func testUserDecodingWithoutEmail() {
-    let user: User? = JSONFromFile("user_without_email") >>- decode
+    let user: User? = JSONFromFile("user_without_email").flatMap(decode)
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)

--- a/ArgoTests/Tests/PListDecodingTests.swift
+++ b/ArgoTests/Tests/PListDecodingTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 import Argo
-import Runes
 
 class PListDecodingTests: XCTestCase {
   func testDecodingAllTypesFromPList() {
-    let model: TestModel? = PListFileReader.plist(fromFile: "types") >>- decode
+    let model: TestModel? = PListFileReader.plist(fromFile: "types").flatMap(decode)
 
     XCTAssert(model != nil)
     XCTAssert(model?.numerics.int == 5)

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import Argo
-import Runes
 
 class PerformanceTests: XCTestCase {
   func testParsePerformance() {

--- a/ArgoTests/Tests/TypeTests.swift
+++ b/ArgoTests/Tests/TypeTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 import Argo
-import Runes
 
 class TypeTests: XCTestCase {
   func testAllTheTypes() {
-    let model: TestModel? = JSONFromFile("types") >>- decode
+    let model: TestModel? = JSONFromFile("types").flatMap(decode)
 
     XCTAssert(model != nil)
     XCTAssert(model?.numerics.int == 5)
@@ -25,7 +24,7 @@ class TypeTests: XCTestCase {
   }
 
   func testFailingEmbedded() {
-    let model: TestModel? = JSONFromFile("types_fail_embedded") >>- decode
+    let model: TestModel? = JSONFromFile("types_fail_embedded").flatMap(decode)
 
     XCTAssert(model == nil)
   }


### PR DESCRIPTION
Accidentally missed some references to Runes in the tests (no clue how
this compiled with those references) so those are gone now.

Also taking the opportunity to clean up our use of init when currying. I
personally prefer using `self.init` instead of specifying the model
name. I'd _rather_ just do `curry(init)`, but the compiler isn't super
smart about that yet and complains about us trying to define an
initializer.