### PR TITLE
fix missing Curry Xcode project

### DIFF
--- a/Argo.xcworkspace/xcshareddata/Argo.xcscmblueprint
+++ b/Argo.xcworkspace/xcshareddata/Argo.xcscmblueprint
@@ -4,13 +4,14 @@
 
   },
   "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
-    "57C931977B7D2307CC013C2BD93F90CF7C676790" : 0,
+    "194A7A54F3CE0138A6C320E0643B7C60F8218891" : 0,
     "0A5C3A6DB1EA9211CEFA5384E9882B4D710699A4" : 0,
-    "39CB70283A1C33AFB5FF861E924945826EDC74FE" : 0
+    "39CB70283A1C33AFB5FF861E924945826EDC74FE" : 0,
+    "57C931977B7D2307CC013C2BD93F90CF7C676790" : 0
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "45EA7014-7CC4-4738-90EB-0191C702E6C9",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "57C931977B7D2307CC013C2BD93F90CF7C676790" : "Argo\/Carthage\/Checkouts\/Box\/",
+    "194A7A54F3CE0138A6C320E0643B7C60F8218891" : "Argo\/Carthage\/Checkouts\/Curry\/",
     "0A5C3A6DB1EA9211CEFA5384E9882B4D710699A4" : "Argo\/Carthage\/Checkouts\/Runes\/",
     "39CB70283A1C33AFB5FF861E924945826EDC74FE" : "Argo\/"
   },
@@ -24,14 +25,14 @@
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "0A5C3A6DB1EA9211CEFA5384E9882B4D710699A4"
     },
     {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/thoughtbot\/Curry.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "194A7A54F3CE0138A6C320E0643B7C60F8218891"
+    },
+    {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:thoughtbot\/Argo.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "39CB70283A1C33AFB5FF861E924945826EDC74FE"
-    },
-    {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "https:\/\/github.com\/robrix\/Box.git",
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "57C931977B7D2307CC013C2BD93F90CF7C676790"
     }
   ]
 }

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "thoughtbot/Curry"
+github "thoughtbot/Curry" "master"
 github "thoughtbot/Runes" "v3.0.0-rc.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
+github "thoughtbot/Curry" "a4c1c730f5189e126968ea6f7326de989efa264f"
 github "thoughtbot/Runes" "5708b06f24fb3e4371ff7c15be8c07256a9bc389"
-github "thoughtbot/Curry" "v1.0.0"


### PR DESCRIPTION
if using `thoughtbot/Curry` without a branch and there is a tagged release version with a binary attached on github, Carthage will only fetch the precompiled framework and won't fetch the associated Xcode project required by Argo