### PR TITLE
Expose functions outside module to support easier extension

### DIFF
--- a/Argo/Functions/flatReduce.swift
+++ b/Argo/Functions/flatReduce.swift
@@ -1,4 +1,4 @@
-func flatReduce<S: SequenceType, U>(sequence: S, initial: U, combine: (U, S.Generator.Element) -> Decoded<U>) -> Decoded<U> {
+public func flatReduce<S: SequenceType, U>(sequence: S, initial: U, combine: (U, S.Generator.Element) -> Decoded<U>) -> Decoded<U> {
   return sequence.reduce(pure(initial)) { accum, x in
     accum >>- { combine($0, x) }
   }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -78,7 +78,7 @@ public extension Dictionary where Value: Decodable, Value == Value.DecodedType {
   }
 }
 
-func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
+public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
   case let .Object(o): return guardNull(key, j: o[key] ?? .Null)
   default: return typeMismatch("Object", forObject: json)


### PR DESCRIPTION
A little while back I asked about how to handle `[String:String]` - see #114. Thanks to some changes in Argo and your guidance in that issue, I could create my own operators and life was good.

In the move to Swift 2, though, some of the requisite functions have had their visibility reduced so aren't accessible when defining operators outside the Argo module.

For example, the following custom operators to support `[String:Decodable]` barf because `flatReduce` and `decodedJSON` aren't visible. I started by copy/pasting those functions, but I also needed to copy/paste `guardNull` and `typeMismatch` and it started to get ugly.

	public func <|~ <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[String:A]> {
		return json <|~ [key]
	}
	public func <|~? <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<[String:A]?> {
		return .optional(json <|~ [key])
	}
	public func <|~ <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[String:A]> {
		return flatReduce(keys, initial: json, combine: decodedJSON) >>- Dictionary<String,A>.decode
	}
	public func <|~? <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> Decoded<[String:A]?> {
		return .optional(json <|~ keys)
	}

This PR stops that boilerplate copying by defining `flatReduce` and `decodedJSON` as public.