### PR TITLE
Document monadic operators for Decoded.

### DIFF
--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -76,8 +76,8 @@ public func pure<A>(a: A) -> Decoded<A> {
   - If the value is a failing case (`.TypeMismatch`, `.MissingKey`), the function will not be evaluated and this will return the value
   - If the value is `.Success`, the function will be applied to the unwrapped value
 
-  - parameter a: A value of type `Decoded<T>`
-  - parameter f: A transformation function from type `T` to type `Decoded<U>`
+  - parameter a: A value of type `Decoded<A>`
+  - parameter f: A transformation function from type `A` to type `Decoded<B>`
 
   - returns: A value of type `Decoded<U>`
 */
@@ -91,10 +91,10 @@ public func >>- <A, B>(a: Decoded<A>, f: A -> Decoded<B>) -> Decoded<B> {
   - If the value is is a failing case (`.TypeMismatch`, `.MissingKey`), the function will not be evaluated and this will return the value
   - If the value is `.Success`, the function will be applied to the unwrapped value
 
-  - parameter f: A transformation function from type `T` to type `U`
-  - parameter a: A value of type `Decoded<T>`
+  - parameter f: A transformation function from type `A` to type `B`
+  - parameter a: A value of type `Decoded<A>`
 
-  - returns: A value of type `Decoded<U>`
+  - returns: A value of type `Decoded<B>`
 */
 public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
   return a.map(f)
@@ -106,9 +106,9 @@ public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
   - If the function is a `.Success` case and the value is a failure case, return the value
   - If both self and the function are `.Success`, the function will be applied to the unwrapped value
 
-  - parameter f: A Decoded transformation function from type `T` to type `U`
+  - parameter f: A Decoded transformation function from type `A` to type `B`
 
-  - returns: A value of type `Decoded<U>`
+  - returns: A value of type `Decoded<B>`
 */
 public func <*> <A, B>(f: Decoded<A -> B>, a: Decoded<A>) -> Decoded<B> {
   return a.apply(f)

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -103,7 +103,7 @@ public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
 /**
   apply a `Decoded` function to a `Decoded` value
   - If the function is a failing case (`.TypeMismatch`, `.MissingKey`), this will return the function's value
-  - If the function is a `.Success` case and the value is a failure case, return the value
+  - If the function is a `.Success` case and the value is a failure case, this will return the value
   - If both self and the function are `.Success`, the function will be applied to the unwrapped value
 
   - parameter f: A Decoded transformation function from type `A` to type `B`

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -106,7 +106,7 @@ public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
   - If the function is a `.Success` case and the value is a failure case, this will return the value
   - If both self and the function are `.Success`, the function will be applied to the unwrapped value
 
-  - parameter f: A Decoded transformation function from type `A` to type `B`
+  - parameter f: A `Decoded` transformation function from type `A` to type `B`
 
   - returns: A value of type `Decoded<B>`
 */

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -70,14 +70,46 @@ public func pure<A>(a: A) -> Decoded<A> {
 
 // MARK: Monadic Operators
 
+/**
+  flatMap a function over a `Decoded` value (right associative)
+  
+  - If the value is a failing case (`.TypeMismatch`, `.MissingKey`), the function will not be evaluated and this will return the value
+  - If the value is `.Success`, the function will be applied to the unwrapped value
+
+  - parameter a: A value of type `Decoded<T>`
+  - parameter f: A transformation function from type `T` to type `Decoded<U>`
+
+  - returns: A value of type `Decoded<U>`
+*/
 public func >>- <A, B>(a: Decoded<A>, f: A -> Decoded<B>) -> Decoded<B> {
   return a.flatMap(f)
 }
 
+/**
+  map a function over a `Decoded` value
+
+  - If the value is is a failing case (`.TypeMismatch`, `.MissingKey`), the function will not be evaluated and this will return the value
+  - If the value is `.Success`, the function will be applied to the unwrapped value
+
+  - parameter f: A transformation function from type `T` to type `U`
+  - parameter a: A value of type `Decoded<T>`
+
+  - returns: A value of type `Decoded<U>`
+*/
 public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
   return a.map(f)
 }
 
+/**
+  apply a `Decoded` function to a `Decoded` value
+  - If the function is a failing case (`.TypeMismatch`, `.MissingKey`), this will return the function's value
+  - If the function is a `.Success` case and the value is a failure case, return the value
+  - If both self and the function are `.Success`, the function will be applied to the unwrapped value
+
+  - parameter f: A Decoded transformation function from type `T` to type `U`
+
+  - returns: A value of type `Decoded<U>`
+*/
 public func <*> <A, B>(f: Decoded<A -> B>, a: Decoded<A>) -> Decoded<B> {
   return a.apply(f)
 }


### PR DESCRIPTION
Documents the monadic operators (`flatMap`, `map`, `apply`) for `Decoded`.

Option-clicking operators will show documentation in a popover.

![graphics-books-732295](https://cloud.githubusercontent.com/assets/782837/9399375/643ed258-4781-11e5-9090-629dd8c68b4e.gif)

:notebook_with_decorative_cover: :notebook_with_decorative_cover:   :notebook_with_decorative_cover: 
