### PR TITLE
Simplify object parsing.

### DIFF
--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Runes
 
 public enum JSON {
   case Object([Swift.String: JSON])
@@ -13,7 +12,7 @@ public extension JSON {
   static func parse(json: AnyObject) -> JSON {
     switch json {
     case let v as [AnyObject]: return .Array(v.map(parse))
-    case let v as [Swift.String: AnyObject]: return .Object(parse <^> v)
+    case let v as [Swift.String: AnyObject]: return .Object(v.map(parse))
     case let v as Swift.String: return .String(v)
     case let v as NSNumber: return .Number(v)
     default: return .Null

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -13,10 +13,7 @@ public extension JSON {
   static func parse(json: AnyObject) -> JSON {
     switch json {
     case let v as [AnyObject]: return .Array(v.map(parse))
-
-    case let v as [Swift.String: AnyObject]:
-      return .Object(parse <^> v)
-
+    case let v as [Swift.String: AnyObject]: return .Object(parse <^> v)
     case let v as Swift.String: return .String(v)
     case let v as NSNumber: return .Number(v)
     default: return .Null

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -15,10 +15,7 @@ public extension JSON {
     case let v as [AnyObject]: return .Array(v.map(parse))
 
     case let v as [Swift.String: AnyObject]:
-      return .Object(reduce(v, [:]) { (var accum, elem) in
-        accum[elem.0] = self.parse(elem.1)
-        return accum
-      })
+      return .Object(parse <^> v)
 
     case let v as Swift.String: return .String(v)
     case let v as NSNumber: return .Number(v)

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -16,8 +16,7 @@ public extension JSON {
 
     case let v as [Swift.String: AnyObject]:
       return .Object(reduce(v, [:]) { (var accum, elem) in
-        let parsedValue = (self.parse <^> elem.1) ?? .Null
-        accum[elem.0] = parsedValue
+        accum[elem.0] = self.parse(elem.1)
         return accum
       })
 


### PR DESCRIPTION
This pull request simplifies the conversion from `[Swift.String: AnyObject]` to it's JSON equivalent.

The use of the nil coalescing operator in the existing implementation seems somewhat redundant since `.Null` is already the default case for the `parse` method.

Perhaps I'm missing something here so would love to understand if I got something wrong.