### PR TITLE
Removed Runes submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Carthage/Checkouts/Runes"]
-	path = Carthage/Checkouts/Runes
-	url = https://github.com/thoughtbot/Runes.git
 [submodule "Carthage/Checkouts/Curry"]
 	path = Carthage/Checkouts/Curry
 	url = https://github.com/thoughtbot/Curry.git


### PR DESCRIPTION
This pull request removes the old submodule entries for Runes.

I believe that Runes is no longer used on this branch and this information was left around due to https://github.com/Carthage/Carthage/issues/442.

I looked into this after reading #207.