### PR TITLE
Change Decoded to look more like Result

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		F802D4C71A5EE2D5005E236C /* url.json in Resources */ = {isa = PBXBuildFile; fileRef = F802D4C51A5EE2D5005E236C /* url.json */; };
 		F84290291B57EFAE008F57B4 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F84290281B57EFAE008F57B4 /* Curry.framework */; };
 		F842902B1B57EFB5008F57B4 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F842902A1B57EFB5008F57B4 /* Curry.framework */; };
+		F84318A81B9A2D7A00165216 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84318A71B9A2D7A00165216 /* DecodeError.swift */; settings = {ASSET_TAGS = (); }; };
+		F84318A91B9A2D7A00165216 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84318A71B9A2D7A00165216 /* DecodeError.swift */; settings = {ASSET_TAGS = (); }; };
+		F84318AA1B9A2D7A00165216 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84318A71B9A2D7A00165216 /* DecodeError.swift */; settings = {ASSET_TAGS = (); }; };
 		F862E0AB1A519D470093B028 /* TypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA08313019D5EEAF003B90D7 /* TypeTests.swift */; };
 		F862E0AC1A519D520093B028 /* post_comments.json in Resources */ = {isa = PBXBuildFile; fileRef = EA08313219D5EEF2003B90D7 /* post_comments.json */; };
 		F862E0AD1A519D560093B028 /* types.json in Resources */ = {isa = PBXBuildFile; fileRef = EA08313419D5EFC0003B90D7 /* types.json */; };
@@ -217,6 +220,7 @@
 		F802D4C51A5EE2D5005E236C /* url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = url.json; sourceTree = "<group>"; };
 		F84290281B57EFAE008F57B4 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Curry.framework; path = "Carthage/Checkouts/Curry/build/Debug-iphoneos/Curry.framework"; sourceTree = "<group>"; };
 		F842902A1B57EFB5008F57B4 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Curry.framework; path = Carthage/Checkouts/Curry/build/Debug/Curry.framework; sourceTree = "<group>"; };
+		F84318A71B9A2D7A00165216 /* DecodeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
 		F874B7E91A66BF52004CCE5E /* root_array.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = root_array.json; sourceTree = "<group>"; };
 		F876F1D61B56FBB300B38589 /* Runes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Runes.swift; path = Carthage/Checkouts/Runes/Source/Runes.swift; sourceTree = SOURCE_ROOT; };
 		F87EB6991ABC5F1300E3B0AB /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = curry.swift; sourceTree = "<group>"; };
@@ -460,6 +464,7 @@
 				F87EB69F1ABC5F1300E3B0AB /* JSON.swift */,
 				F87EB6A01ABC5F1300E3B0AB /* Decodable.swift */,
 				F87EB6A11ABC5F1300E3B0AB /* StandardTypes.swift */,
+				F84318A71B9A2D7A00165216 /* DecodeError.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -746,6 +751,7 @@
 				D0592EC51B77DD9A00EFEF39 /* decode.swift in Sources */,
 				D0592EC81B77DD9A00EFEF39 /* Dictionary.swift in Sources */,
 				D0592EBE1B77DD8E00EFEF39 /* Decoded.swift in Sources */,
+				F84318AA1B9A2D7A00165216 /* DecodeError.swift in Sources */,
 				D0592EBF1B77DD8E00EFEF39 /* JSON.swift in Sources */,
 				D0592EC21B77DD9300EFEF39 /* Runes.swift in Sources */,
 				E5DF09021BAA174600704741 /* DecodedOperators.swift in Sources */,
@@ -765,6 +771,7 @@
 				F87EB6AC1ABC5F1300E3B0AB /* JSON.swift in Sources */,
 				F87EB6A61ABC5F1300E3B0AB /* flatReduce.swift in Sources */,
 				F87EB6A81ABC5F1300E3B0AB /* sequence.swift in Sources */,
+				F84318A81B9A2D7A00165216 /* DecodeError.swift in Sources */,
 				F876F1D71B56FBB300B38589 /* Runes.swift in Sources */,
 				F8CBE6671A64521000316FBC /* Dictionary.swift in Sources */,
 				E5DF09001BAA174600704741 /* DecodedOperators.swift in Sources */,
@@ -807,6 +814,7 @@
 				F87EB6AD1ABC5F1300E3B0AB /* JSON.swift in Sources */,
 				F87EB6A71ABC5F1300E3B0AB /* flatReduce.swift in Sources */,
 				F87EB6A91ABC5F1300E3B0AB /* sequence.swift in Sources */,
+				F84318A91B9A2D7A00165216 /* DecodeError.swift in Sources */,
 				F876F1D81B56FBB300B38589 /* Runes.swift in Sources */,
 				F8CBE6681A64526300316FBC /* Dictionary.swift in Sources */,
 				E5DF09011BAA174600704741 /* DecodedOperators.swift in Sources */,

--- a/Argo/Types/DecodeError.swift
+++ b/Argo/Types/DecodeError.swift
@@ -1,0 +1,13 @@
+public enum DecodeError: ErrorType {
+  case TypeMismatch(expected: String, actual: String)
+  case MissingKey(String)
+}
+
+extension DecodeError: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .TypeMismatch(expected, actual): return "TypeMismatch(Expected \(expected), got \(actual))"
+    case let .MissingKey(s): return "MissingKey(\(s))"
+    }
+  }
+}

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -1,17 +1,3 @@
-public enum DecodeError: ErrorType {
-  case TypeMismatch(expected: String, actual: String)
-  case MissingKey(String)
-}
-
-extension DecodeError: CustomStringConvertible {
-  public var description: String {
-    switch self {
-    case let .TypeMismatch(expected, actual): return "TypeMismatch(Expected \(expected), got \(actual))"
-    case let .MissingKey(s): return "MissingKey(\(s))"
-    }
-  }
-}
-
 public enum Decoded<T> {
   case Success(T)
   case Failure(DecodeError)

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -33,7 +33,7 @@ public extension Decoded {
   }
 
   static func typeMismatch<T>(expected: String, actual: String) -> Decoded<T> {
-    return .Failure(.TypeMismatch(expected: expected, actual: "\(actual)"))
+    return .Failure(.TypeMismatch(expected: expected, actual: actual))
   }
 
   static func missingKey<T>(name: String) -> Decoded<T> {

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -1,7 +1,20 @@
-public enum Decoded<T> {
-  case Success(T)
+public enum DecodeError: ErrorType {
   case TypeMismatch(String)
   case MissingKey(String)
+}
+
+extension DecodeError: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .TypeMismatch(s): return "TypeMismatch(\(s))"
+    case let .MissingKey(s): return "MissingKey(\(s))"
+    }
+  }
+}
+
+public enum Decoded<T> {
+  case Success(T)
+  case Failure(DecodeError)
 
   public var value: T? {
     switch self {
@@ -15,15 +28,15 @@ public extension Decoded {
   static func optional<T>(x: Decoded<T>) -> Decoded<T?> {
     switch x {
     case let .Success(value): return .Success(.Some(value))
-    case .MissingKey: return .Success(.None)
-    case let .TypeMismatch(string): return .TypeMismatch(string)
+    case .Failure(.MissingKey): return .Success(.None)
+    case let .Failure(.TypeMismatch(string)): return .Failure(.TypeMismatch(string))
     }
   }
 
   static func fromOptional<T>(x: T?) -> Decoded<T> {
     switch x {
     case let .Some(value): return .Success(value)
-    case .None: return .TypeMismatch("Expected .Some(\(T.self)), got .None")
+    case .None: return .Failure(.TypeMismatch("Expected .Some(\(T.self)), got .None"))
     }
   }
 }
@@ -31,9 +44,8 @@ public extension Decoded {
 extension Decoded: CustomStringConvertible {
   public var description: String {
     switch self {
-    case let .Success(x): return "Success(\(x))"
-    case let .TypeMismatch(s): return "TypeMismatch(\(s))"
-    case let .MissingKey(s): return "MissingKey(\(s))"
+    case let .Success(value): return "Success(\(value))"
+    case let .Failure(error): return "Failure(\(error))"
     }
   }
 }
@@ -42,24 +54,21 @@ public extension Decoded {
   func map<U>(f: T -> U) -> Decoded<U> {
     switch self {
     case let .Success(value): return .Success(f(value))
-    case let .MissingKey(string): return .MissingKey(string)
-    case let .TypeMismatch(string): return .TypeMismatch(string)
+    case let .Failure(error): return .Failure(error)
     }
   }
 
   func apply<U>(f: Decoded<T -> U>) -> Decoded<U> {
     switch f {
-    case let .Success(value): return value <^> self
-    case let .MissingKey(string): return .MissingKey(string)
-    case let .TypeMismatch(string): return .TypeMismatch(string)
+    case let .Success(function): return self.map(function)
+    case let .Failure(error): return .Failure(error)
     }
   }
 
   func flatMap<U>(f: T -> Decoded<U>) -> Decoded<U> {
     switch self {
     case let .Success(value): return f(value)
-    case let .MissingKey(string): return .MissingKey(string)
-    case let .TypeMismatch(string): return .TypeMismatch(string)
+    case let .Failure(error): return .Failure(error)
     }
   }
 }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -4,7 +4,7 @@ extension String: Decodable {
   public static func decode(j: JSON) -> Decoded<String> {
     switch j {
     case let .String(s): return pure(s)
-    default: return typeMismatch("String", forObject: j)
+    default: return .typeMismatch("String", actual: j)
     }
   }
 }
@@ -13,7 +13,7 @@ extension Int: Decodable {
   public static func decode(j: JSON) -> Decoded<Int> {
     switch j {
     case let .Number(n): return pure(n as Int)
-    default: return typeMismatch("Int", forObject: j)
+    default: return .typeMismatch("Int", actual: j)
     }
   }
 }
@@ -22,7 +22,7 @@ extension Int64: Decodable {
   public static func decode(j: JSON) -> Decoded<Int64> {
     switch j {
     case let .Number(n): return pure(n.longLongValue)
-    default: return typeMismatch("Int64", forObject: j)
+    default: return .typeMismatch("Int64", actual: j)
     }
   }
 }
@@ -31,7 +31,7 @@ extension Double: Decodable {
   public static func decode(j: JSON) -> Decoded<Double> {
     switch j {
     case let .Number(n): return pure(n as Double)
-    default: return typeMismatch("Double", forObject: j)
+    default: return .typeMismatch("Double", actual: j)
     }
   }
 }
@@ -40,7 +40,7 @@ extension Bool: Decodable {
   public static func decode(j: JSON) -> Decoded<Bool> {
     switch j {
     case let .Number(n): return pure(n as Bool)
-    default: return typeMismatch("Bool", forObject: j)
+    default: return .typeMismatch("Bool", actual: j)
     }
   }
 }
@@ -49,7 +49,7 @@ extension Float: Decodable {
   public static func decode(j: JSON) -> Decoded<Float> {
     switch j {
     case let .Number(n): return pure(n as Float)
-    default: return typeMismatch("Float", forObject: j)
+    default: return .typeMismatch("Float", actual: j)
     }
   }
 }
@@ -64,7 +64,7 @@ public extension Array where Element: Decodable, Element == Element.DecodedType 
   static func decode(j: JSON) -> Decoded<[Element]> {
     switch j {
     case let .Array(a): return sequence(a.map(Element.decode))
-    default: return typeMismatch("Array", forObject: j)
+    default: return .typeMismatch("Array", actual: "\(j)")
     }
   }
 }
@@ -73,7 +73,7 @@ public extension Dictionary where Value: Decodable, Value == Value.DecodedType {
   static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
     case let .Object(o): return sequence(Value.decode <^> o)
-    default: return typeMismatch("Object", forObject: j)
+    default: return .typeMismatch("Object", actual: "\(j)")
     }
   }
 }
@@ -81,17 +81,13 @@ public extension Dictionary where Value: Decodable, Value == Value.DecodedType {
 public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
   case let .Object(o): return guardNull(key, j: o[key] ?? .Null)
-  default: return typeMismatch("Object", forObject: json)
+  default: return .typeMismatch("Object", actual: "\(json)")
   }
-}
-
-private func typeMismatch<T>(expectedType: String, forObject object: JSON) -> Decoded<T> {
-  return .Failure(.TypeMismatch("\(object) is not a \(expectedType)"))
 }
 
 private func guardNull(key: String, j: JSON) -> Decoded<JSON> {
   switch j {
-  case .Null: return .Failure(.MissingKey(key))
+  case .Null: return .missingKey(key)
   default: return pure(j)
   }
 }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -86,12 +86,12 @@ public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
 }
 
 private func typeMismatch<T>(expectedType: String, forObject object: JSON) -> Decoded<T> {
-  return .TypeMismatch("\(object) is not a \(expectedType)")
+  return .Failure(.TypeMismatch("\(object) is not a \(expectedType)"))
 }
 
 private func guardNull(key: String, j: JSON) -> Decoded<JSON> {
   switch j {
-  case .Null: return .MissingKey(key)
+  case .Null: return .Failure(.MissingKey(key))
   default: return pure(j)
   }
 }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -64,7 +64,7 @@ public extension Array where Element: Decodable, Element == Element.DecodedType 
   static func decode(j: JSON) -> Decoded<[Element]> {
     switch j {
     case let .Array(a): return sequence(a.map(Element.decode))
-    default: return .typeMismatch("Array", actual: "\(j)")
+    default: return .typeMismatch("Array", actual: j)
     }
   }
 }
@@ -73,7 +73,7 @@ public extension Dictionary where Value: Decodable, Value == Value.DecodedType {
   static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
     case let .Object(o): return sequence(Value.decode <^> o)
-    default: return .typeMismatch("Object", actual: "\(j)")
+    default: return .typeMismatch("Object", actual: j)
     }
   }
 }
@@ -81,7 +81,7 @@ public extension Dictionary where Value: Decodable, Value == Value.DecodedType {
 public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
   case let .Object(o): return guardNull(key, j: o[key] ?? .Null)
-  default: return .typeMismatch("Object", actual: "\(json)")
+  default: return .typeMismatch("Object", actual: json)
   }
 }
 

--- a/ArgoTests/Models/NSURL.swift
+++ b/ArgoTests/Models/NSURL.swift
@@ -7,8 +7,8 @@ extension NSURL: Decodable {
   public class func decode(j: JSON) -> Decoded<NSURL> {
     switch j {
     case .String(let urlString):
-      return NSURL(string: urlString).map(pure) ?? .Failure(.TypeMismatch("\(j) is not a URL"))
-    default: return .Failure(.TypeMismatch("\(j) is not a URL"))
+      return NSURL(string: urlString).map(pure) ?? .typeMismatch("URL", actual: j)
+    default: return .typeMismatch("URL", actual: j)
     }
   }
 }

--- a/ArgoTests/Models/NSURL.swift
+++ b/ArgoTests/Models/NSURL.swift
@@ -7,8 +7,8 @@ extension NSURL: Decodable {
   public class func decode(j: JSON) -> Decoded<NSURL> {
     switch j {
     case .String(let urlString):
-      return NSURL(string: urlString).map(pure) ?? .TypeMismatch("\(j) is not a URL")
-    default: return .TypeMismatch("\(j) is not a URL")
+      return NSURL(string: urlString).map(pure) ?? .Failure(.TypeMismatch("\(j) is not a URL"))
+    default: return .Failure(.TypeMismatch("\(j) is not a URL"))
     }
   }
 }

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -15,7 +15,7 @@ class DecodedTests: XCTestCase {
     let user: Decoded<User> = decode(JSONFromFile("user_with_bad_type")!)
 
     switch user {
-    case let .Failure(.TypeMismatch(s)): XCTAssert(user.description == "Failure(TypeMismatch(\(s)))")
+    case let .Failure(.TypeMismatch(expected, actual)): XCTAssert(user.description == "Failure(TypeMismatch(Expected \(expected), got \(actual)))")
     default: XCTFail("Unexpected Case Occurred")
     }
   }

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -15,7 +15,7 @@ class DecodedTests: XCTestCase {
     let user: Decoded<User> = decode(JSONFromFile("user_with_bad_type")!)
 
     switch user {
-    case let .TypeMismatch(s): XCTAssert(user.description == "TypeMismatch(\(s))")
+    case let .Failure(.TypeMismatch(s)): XCTAssert(user.description == "Failure(TypeMismatch(\(s)))")
     default: XCTFail("Unexpected Case Occurred")
     }
   }
@@ -24,7 +24,7 @@ class DecodedTests: XCTestCase {
     let user: Decoded<User> = decode(JSONFromFile("user_without_key")!)
 
     switch user {
-    case let .MissingKey(s): XCTAssert(user.description == "MissingKey(\(s))")
+    case let .Failure(.MissingKey(s)): XCTAssert(user.description == "Failure(MissingKey(\(s)))")
     default: XCTFail("Unexpected Case Occurred")
     }
   }


### PR DESCRIPTION
This ditches the strategy of using multiple error states, for using a
single error state with multiple possible error causes.

The end result here is a simpler Decoded type, without sacrificing the
flexibility and expressiveness that we'd run into by switching to Result
itself. Additionally, this will make transforming from Decoded to Result
completely trivial:

```swift
func makeResult<T>(d: Deocded<T>) -> Result<T, DecodeError> {
 switch d {
 case let .Success(value): return .Success(value)
 case let .Failure(error): return .Failure(error)
 }
}
```

I've also added helper functions for failing states. It was always kind of
annoying to have to create these yourself, even more so now that you have to
wrap multiple types. This adds some more semantic static functions so that it's
cleaner to create these if needed.