### PR TITLE
Update Curry to newest version

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "thoughtbot/Runes" "5708b06f24fb3e4371ff7c15be8c07256a9bc389"
-github "thoughtbot/Curry" "v1.0.0"
+github "thoughtbot/Curry" "v1.1.1"
+github "thoughtbot/Runes" "v3.0.0-rc.2"


### PR DESCRIPTION
This is _super_ annoying, but Xcode kept yelling at me about needing to
update Curry to the latest syntax. After updating the version here,
Xcode will shut the hell up about it.