### PR TITLE
Uncomment the correct code

### DIFF
--- a/Argo/Operators/Operators.swift
+++ b/Argo/Operators/Operators.swift
@@ -8,7 +8,6 @@ infix operator <|> { associativity left precedence 140 }
 
 // Pull value from JSON
 public func <| <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> Decoded<A> {
-//  return decodedJSON(json, forKey: key) >>- A.decode
   return json <| [key]
 }
 


### PR DESCRIPTION
I can't remember why this was commented. The commented code was
originally used to help with performance. It must have been commented
for experimenting with something else. This commit brings it back.