### PR TITLE
Remove custom string description

### DIFF
--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -30,18 +30,6 @@ extension JSON: Decodable {
   }
 }
 
-extension JSON: CustomStringConvertible {
-  public var description: Swift.String {
-    switch self {
-    case let .String(v): return "String(\(v))"
-    case let .Number(v): return "Number(\(v))"
-    case let .Array(a): return "Array(\(a.description))"
-    case let .Object(o): return "Object(\(o.description))"
-    case .Null: return "Null"
-    }
-  }
-}
-
 extension JSON: Equatable { }
 
 public func == (lhs: JSON, rhs: JSON) -> Bool {


### PR DESCRIPTION
This basic implementation of a custom string now comes by default when
using enums. We can remove this and the default description looks good
enough.

An example is: `Object(["id": Argo.JSON.Number(1), "email":
Argo.JSON.String("u.cool@example.com"), "name": Argo.JSON.String("Cool
User")])`