### PR TITLE
Add dematerialize

### DIFF
--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -76,3 +76,12 @@ public extension Decoded {
 public func pure<A>(a: A) -> Decoded<A> {
   return .Success(a)
 }
+
+public extension Decoded {
+  func dematerialize() throws -> T {
+    switch self {
+    case let .Success(value): return value
+    case let .Failure(error): throw error
+    }
+  }
+}

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -28,4 +28,45 @@ class DecodedTests: XCTestCase {
     default: XCTFail("Unexpected Case Occurred")
     }
   }
+  
+  func testDecodedDematerializeSuccess() {
+    let user: Decoded<User> = decode(JSONFromFile("user_with_email")!)
+    
+    do {
+      try user.dematerialize()
+      XCTAssert(true)
+    } catch {
+      XCTFail("Unexpected Error Occurred")
+    }
+  }
+  
+  func testDecodedDematerializeTypeMismatch() {
+    let user: Decoded<User> = decode(JSONFromFile("user_with_bad_type")!)
+    
+    do {
+      try user.dematerialize()
+      XCTFail("Unexpected Success")
+    } catch DecodeError.TypeMismatch {
+      XCTAssert(true)
+    } catch DecodeError.MissingKey {
+      XCTFail("Unexpected Error Occurred")
+    } catch {
+      XCTFail("Unexpected Error Occurred")
+    }
+  }
+  
+  func testDecodedDematerializeMissingKey() {
+    let user: Decoded<User> = decode(JSONFromFile("user_without_key")!)
+    
+    do {
+      try user.dematerialize()
+      XCTFail("Unexpected Success")
+    } catch DecodeError.MissingKey {
+      XCTAssert(true)
+    } catch DecodeError.TypeMismatch {
+      XCTFail("Unexpected Error Occurred")
+    } catch {
+      XCTFail("Unexpected Error Occurred")
+    }
+  }
 }


### PR DESCRIPTION
This pull request aims to enable going from `Decoded` to `throws` and vice-versa.

Currently this doesn't compile since the `catch` for `materialize` is not exhaustive and I'm not too sure what to do there.