### PR TITLE
Add a Custom error case for DecodeError

### DIFF
--- a/Argo/Types/DecodeError.swift
+++ b/Argo/Types/DecodeError.swift
@@ -1,6 +1,7 @@
 public enum DecodeError: ErrorType {
   case TypeMismatch(expected: String, actual: String)
   case MissingKey(String)
+  case Custom(String)
 }
 
 extension DecodeError: CustomStringConvertible {
@@ -8,6 +9,7 @@ extension DecodeError: CustomStringConvertible {
     switch self {
     case let .TypeMismatch(expected, actual): return "TypeMismatch(Expected \(expected), got \(actual))"
     case let .MissingKey(s): return "MissingKey(\(s))"
+    case let .Custom(s): return "Custom(\(s))"
     }
   }
 }

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -16,6 +16,7 @@ public extension Decoded {
     case let .Success(value): return .Success(.Some(value))
     case .Failure(.MissingKey): return .Success(.None)
     case let .Failure(.TypeMismatch(x)): return .Failure(.TypeMismatch(x))
+    case let .Failure(.Custom(x)): return .Failure(.Custom(x))
     }
   }
 
@@ -38,6 +39,10 @@ public extension Decoded {
 
   static func missingKey<T>(name: String) -> Decoded<T> {
     return .Failure(.MissingKey(name))
+  }
+
+  static func customError<T>(message: String) -> Decoded<T> {
+    return .Failure(.Custom(message))
   }
 }
 

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -28,6 +28,15 @@ class DecodedTests: XCTestCase {
     default: XCTFail("Unexpected Case Occurred")
     }
   }
+
+  func testDecodedCustomError() {
+    let customError: Decoded<Dummy> = decode([:])
+
+    switch customError {
+    case let .Failure(e): XCTAssert(e.description == "Custom(My Custom Error)")
+    default: XCTFail("Unexpected Case Occurred")
+    }
+  }
   
   func testDecodedDematerializeSuccess() {
     let user: Decoded<User> = decode(JSONFromFile("user_with_email")!)
@@ -68,5 +77,11 @@ class DecodedTests: XCTestCase {
     } catch {
       XCTFail("Unexpected Error Occurred")
     }
+  }
+}
+
+private struct Dummy: Decodable {
+  static func decode(json: JSON) -> Decoded<Dummy> {
+    return .Failure(.Custom("My Custom Error"))
   }
 }


### PR DESCRIPTION
This is to help users with error messaging that doesn't really fit into a type mismatch or missing key. See #211.