### PR TITLE
Add `decode` function with root keys

### DIFF
--- a/Argo/Functions/decode.swift
+++ b/Argo/Functions/decode.swift
@@ -1,3 +1,5 @@
+// MARK: decode root objects and arrays
+
 public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> T? {
   return decode(object).value
 }
@@ -12,4 +14,22 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> 
 
 public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> Decoded<[T]> {
   return Array<T>.decode(JSON.parse(object))
+}
+
+// MARK: decode with a root key
+
+public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> T? {
+  return decodeWithRootKey(rootKey, object).value
+}
+
+public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> [T]? {
+  return decodeWithRootKey(rootKey, object).value
+}
+
+public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> Decoded<T> {
+  return JSON.parse(object) <| rootKey
+}
+
+public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> Decoded<[T]> {
+  return JSON.parse(object) <|| rootKey
 }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Argo
+import Curry
 
 class ExampleTests: XCTestCase {
   func testJSONWithRootArray() {
@@ -10,8 +11,7 @@ class ExampleTests: XCTestCase {
   }
 
   func testJSONWithRootObject() {
-    let json = JSONFromFile("root_object").map(JSON.parse)
-    let user: User? = json.flatMap { $0 <| "user" }
+    let user: User? = JSONFromFile("root_object").flatMap(curry(decodeWithRootKey)("user"))
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -21,8 +21,7 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingNonFinalClass() {
-    let json = JSONFromFile("url").map(JSON.parse)
-    let url: NSURL? = json.flatMap { $0 <| "url" }
+    let url: NSURL? = JSONFromFile("url").flatMap(curry(decodeWithRootKey)("url"))
 
     XCTAssert(url != nil)
     XCTAssert(url?.absoluteString == "http://example.com")


### PR DESCRIPTION
The current `decode` function can't decode models from JSON where the
JSON for that model is embedded within a root key. This is a very common
thing so this is an attempt to make it easier to decode those objects.

This solves #141 and might be a better solution than 8483513b9340025729bbf396c85ea4ac532c160d