### PR TITLE
Extend CollectionType intead of extending Array

### DIFF
--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -60,10 +60,10 @@ public extension Optional where Wrapped: Decodable, Wrapped == Wrapped.DecodedTy
   }
 }
 
-public extension Array where Element: Decodable, Element == Element.DecodedType {
-  static func decode(j: JSON) -> Decoded<[Element]> {
+public extension CollectionType where Generator.Element: Decodable, Generator.Element == Generator.Element.DecodedType {
+  static func decode(j: JSON) -> Decoded<[Generator.Element]> {
     switch j {
-    case let .Array(a): return sequence(a.map(Element.decode))
+    case let .Array(a): return sequence(a.map(Generator.Element.decode))
     default: return .typeMismatch("Array", actual: j)
     }
   }


### PR DESCRIPTION
Extending Array was great, but it'd be nicer if we could extend _any_
collection type that contains Decodable objects. This `decode` function
will still always return an Array, for the same reason that the stdlib's
`map`, `flatMap`, etc return Arrays, but if we ever get Real Actual
Higher Kinded Types, we can fix this.

Note that this _almost_ works with Dictionary as well, except that it would
always return an array, instead of returning a dictionary. Bummer.