### PR TITLE
Add tests for decoding dictionaries

### DIFF
--- a/ArgoTests/JSON/types.json
+++ b/ArgoTests/JSON/types.json
@@ -22,5 +22,8 @@
   "user_opt": {
     "id": 6,
     "name": "Cooler User"
+  },
+  "dict": {
+    "foo": "bar"
   }
 }

--- a/ArgoTests/Models/TestModel.swift
+++ b/ArgoTests/Models/TestModel.swift
@@ -10,10 +10,19 @@ struct TestModel {
   let eStringArray: [String]
   let eStringArrayOpt: [String]?
   let userOpt: User?
+  let dict: [String: String]
 }
 
 extension TestModel: Decodable {
   static func decode(j: JSON) -> Decoded<TestModel> {
+    let json: Decoded<JSON> = j <| "dict"
+    let dict: Decoded<[String: String]>
+
+    switch json {
+    case let .Success(js): dict = [String: String].decode(js)
+    case let .Failure(e): dict = .Failure(e)
+    }
+
     return curry(self.init)
       <^> j <| "numerics"
       <*> j <| ["user_opt", "name"]
@@ -23,6 +32,7 @@ extension TestModel: Decodable {
       <*> j <|| ["embedded", "string_array"]
       <*> j <||? ["embedded", "string_array_opt"]
       <*> j <|? "user_opt"
+      <*> dict
   }
 }
 

--- a/ArgoTests/Tests/PListDecodingTests.swift
+++ b/ArgoTests/Tests/PListDecodingTests.swift
@@ -20,5 +20,6 @@ class PListDecodingTests: XCTestCase {
     XCTAssert(model?.eStringArrayOpt?.count == 0)
     XCTAssert(model?.userOpt != nil)
     XCTAssert(model?.userOpt?.id == 6)
+    XCTAssert(model!.dict == ["foo": "bar"])
   }
 }

--- a/ArgoTests/Tests/PListDecodingTests.swift
+++ b/ArgoTests/Tests/PListDecodingTests.swift
@@ -20,6 +20,6 @@ class PListDecodingTests: XCTestCase {
     XCTAssert(model?.eStringArrayOpt?.count == 0)
     XCTAssert(model?.userOpt != nil)
     XCTAssert(model?.userOpt?.id == 6)
-    XCTAssert(model!.dict == ["foo": "bar"])
+    XCTAssert(model?.dict ?? [:] == ["foo": "bar"])
   }
 }

--- a/ArgoTests/Tests/SwiftDictionaryDecodingTests.swift
+++ b/ArgoTests/Tests/SwiftDictionaryDecodingTests.swift
@@ -20,6 +20,9 @@ class SwiftDictionaryDecodingTests: XCTestCase {
       "user_opt": [
         "id": 6,
         "name": "Cooler User"
+      ],
+      "dict": [
+        "foo": "bar"
       ]
     ]
 
@@ -41,5 +44,6 @@ class SwiftDictionaryDecodingTests: XCTestCase {
     XCTAssert(model?.eStringArrayOpt?.count == 0)
     XCTAssert(model?.userOpt != nil)
     XCTAssert(model?.userOpt?.id == 6)
+    XCTAssert(model!.dict == ["foo": "bar"])
   }
 }

--- a/ArgoTests/Tests/SwiftDictionaryDecodingTests.swift
+++ b/ArgoTests/Tests/SwiftDictionaryDecodingTests.swift
@@ -44,6 +44,6 @@ class SwiftDictionaryDecodingTests: XCTestCase {
     XCTAssert(model?.eStringArrayOpt?.count == 0)
     XCTAssert(model?.userOpt != nil)
     XCTAssert(model?.userOpt?.id == 6)
-    XCTAssert(model!.dict == ["foo": "bar"])
+    XCTAssert(model?.dict ?? [:] == ["foo": "bar"])
   }
 }

--- a/ArgoTests/Tests/TypeTests.swift
+++ b/ArgoTests/Tests/TypeTests.swift
@@ -21,6 +21,7 @@ class TypeTests: XCTestCase {
     XCTAssert(model?.eStringArrayOpt?.count == 0)
     XCTAssert(model?.userOpt != nil)
     XCTAssert(model?.userOpt?.id == 6)
+    XCTAssert(model!.dict == ["foo": "bar"])
   }
 
   func testFailingEmbedded() {

--- a/ArgoTests/Tests/TypeTests.swift
+++ b/ArgoTests/Tests/TypeTests.swift
@@ -21,7 +21,7 @@ class TypeTests: XCTestCase {
     XCTAssert(model?.eStringArrayOpt?.count == 0)
     XCTAssert(model?.userOpt != nil)
     XCTAssert(model?.userOpt?.id == 6)
-    XCTAssert(model!.dict == ["foo": "bar"])
+    XCTAssert(model?.dict ?? [:] == ["foo": "bar"])
   }
 
   func testFailingEmbedded() {

--- a/ArgoTests/plists/types.plist
+++ b/ArgoTests/plists/types.plist
@@ -37,5 +37,10 @@
 		<key>name</key>
 		<string>Cooler User</string>
 	</dict>
+	<key>dict</key>
+	<dict>
+		<key>foo</key>
+		<string>bar</string>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Turns out, we weren't testing the decoding of dictionaries anywhere.
That seems wrong, so this adds those tests and (thankfully) proves that
our current implementation works as expected.

Also, we ran into a swift bug that I actually hit the other day as well
that I need to file a radar on. The title of which will probably end up
being:

> flatMapping custom monadic type with static function defined in a
> protocol extension results in compiler crash

That's why we're duplicating the meat of `flatMap` for the purpose of
the test.