### PR TITLE
Extend CollectionType instead of Dictionary

### DIFF
--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -69,10 +69,10 @@ public extension Array where Element: Decodable, Element == Element.DecodedType 
   }
 }
 
-public extension CollectionType where Self: DictionaryLiteralConvertible, Self.Value: Decodable, Self.Value == Self.Value.DecodedType {
-  static func decode(j: JSON) -> Decoded<[String: Self.Value]> {
+public extension DictionaryLiteralConvertible where Value: Decodable, Value == Value.DecodedType {
+  static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
-    case let .Object(o): return sequence(Self.Value.decode <^> o)
+    case let .Object(o): return sequence(Value.decode <^> o)
     default: return .typeMismatch("Object", actual: j)
     }
   }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -69,10 +69,10 @@ public extension Array where Element: Decodable, Element == Element.DecodedType 
   }
 }
 
-public extension Dictionary where Value: Decodable, Value == Value.DecodedType {
-  static func decode(j: JSON) -> Decoded<[String: Value]> {
+public extension CollectionType where Self: DictionaryLiteralConvertible, Self.Value: Decodable, Self.Value == Self.Value.DecodedType {
+  static func decode(j: JSON) -> Decoded<[String: Self.Value]> {
     switch j {
-    case let .Object(o): return sequence(Value.decode <^> o)
+    case let .Object(o): return sequence(Self.Value.decode <^> o)
     default: return .typeMismatch("Object", actual: j)
     }
   }


### PR DESCRIPTION
> Similar to #243, in which we extended CollectionType instead of
Array to parse any collection of Decodable obects. That, however,
always returns an Array, so here we extend CollectionType again
(for cases where Self is DictionaryLiteralConvertible) and instead
return a Dictionary of Decoded objects.

Ideally, as mentioned in #243, we'd be able to wrap this into a single extension on `CollectionType` that can handle both `Array` and `Dictionary`. Until then, this replaces the `Dictionary` extension and lets you parse any `DictionaryLiteralConvertible` collection of `Decodable` objects.

This also passes the dictionary decoding tests in #244

Thanks @paulyoung for sharing the [Ogra diff](https://github.com/edwardaux/Ogra/pull/1/files) that inspired this change