### PR TITLE
Add catDecoded and ?? to Decoded

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -116,6 +116,9 @@
 		F8CBE6671A64521000316FBC /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6661A64521000316FBC /* Dictionary.swift */; };
 		F8CBE6681A64526300316FBC /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CBE6661A64521000316FBC /* Dictionary.swift */; };
 		F8E33FA51A51E0C20025A6E5 /* post_bad_comments.json in Resources */ = {isa = PBXBuildFile; fileRef = F8E33FA41A51E0C20025A6E5 /* post_bad_comments.json */; };
+		F8EF432F1BBC728A001886BA /* catDecoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF432E1BBC728A001886BA /* catDecoded.swift */; settings = {ASSET_TAGS = (); }; };
+		F8EF43301BBC729F001886BA /* catDecoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF432E1BBC728A001886BA /* catDecoded.swift */; settings = {ASSET_TAGS = (); }; };
+		F8EF43311BBC729F001886BA /* catDecoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF432E1BBC728A001886BA /* catDecoded.swift */; settings = {ASSET_TAGS = (); }; };
 		F8EF756A1A4CEC6100BDCC2D /* OptionalPropertyDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FB0D19D215570031E006 /* OptionalPropertyDecodingTests.swift */; };
 		F8EF756B1A4CEC6400BDCC2D /* EmbeddedJSONDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FB1119D30E660031E006 /* EmbeddedJSONDecodingTests.swift */; };
 		F8EF756C1A4CEC7100BDCC2D /* JSONFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9FB0F19D21AF50031E006 /* JSONFileReader.swift */; };
@@ -247,6 +250,7 @@
 		F893356D1A4CE8FC00B88685 /* Argo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Argo.h; sourceTree = "<group>"; };
 		F8CBE6661A64521000316FBC /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		F8E33FA41A51E0C20025A6E5 /* post_bad_comments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = post_bad_comments.json; sourceTree = "<group>"; };
+		F8EF432E1BBC728A001886BA /* catDecoded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = catDecoded.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -462,6 +466,7 @@
 		F87EB6981ABC5F1300E3B0AB /* Functions */ = {
 			isa = PBXGroup;
 			children = (
+				F8EF432E1BBC728A001886BA /* catDecoded.swift */,
 				F87EB6991ABC5F1300E3B0AB /* curry.swift */,
 				F87EB69A1ABC5F1300E3B0AB /* decode.swift */,
 				F87EB69B1ABC5F1300E3B0AB /* flatReduce.swift */,
@@ -770,6 +775,7 @@
 				D0592EBF1B77DD8E00EFEF39 /* JSON.swift in Sources */,
 				D0592EC21B77DD9300EFEF39 /* Runes.swift in Sources */,
 				E5DF09021BAA174600704741 /* DecodedOperators.swift in Sources */,
+				F8EF43311BBC729F001886BA /* catDecoded.swift in Sources */,
 				D0592EC31B77DD9300EFEF39 /* Operators.swift in Sources */,
 				EA1200CE1BAB621C006DDBD8 /* RawRepresentable.swift in Sources */,
 				D0592EC71B77DD9A00EFEF39 /* sequence.swift in Sources */,
@@ -796,6 +802,7 @@
 				EAD9FAF619D0F7900031E006 /* Operators.swift in Sources */,
 				F87EB6B01ABC5F1300E3B0AB /* StandardTypes.swift in Sources */,
 				F87EB6A21ABC5F1300E3B0AB /* curry.swift in Sources */,
+				F8EF432F1BBC728A001886BA /* catDecoded.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -838,6 +845,7 @@
 				F876F1D81B56FBB300B38589 /* Runes.swift in Sources */,
 				F8CBE6681A64526300316FBC /* Dictionary.swift in Sources */,
 				E5DF09011BAA174600704741 /* DecodedOperators.swift in Sources */,
+				F8EF43301BBC729F001886BA /* catDecoded.swift in Sources */,
 				F89335761A4CE93600B88685 /* Operators.swift in Sources */,
 				EA1200CD1BAB621C006DDBD8 /* RawRepresentable.swift in Sources */,
 				F87EB6B11ABC5F1300E3B0AB /* StandardTypes.swift in Sources */,

--- a/Argo/Functions/catDecoded.swift
+++ b/Argo/Functions/catDecoded.swift
@@ -1,0 +1,5 @@
+public func catDecoded<T>(xs: [Decoded<T>]) -> [T] {
+  return xs.reduce([]) { accum, elem in
+    return elem.map { accum + [$0] } ?? accum
+  }
+}

--- a/Argo/Functions/catDecoded.swift
+++ b/Argo/Functions/catDecoded.swift
@@ -1,5 +1,11 @@
 public func catDecoded<T>(xs: [Decoded<T>]) -> [T] {
   return xs.reduce([]) { accum, elem in
-    return elem.map { accum + [$0] } ?? accum
+    elem.map { accum + [$0] } ?? accum
+  }
+}
+
+public func catDecoded<T>(xs: [String: Decoded<T>]) -> [String: T] {
+  return xs.reduce([:]) { accum, elem in
+    elem.1.map { accum + [elem.0: $0] } ?? accum
   }
 }

--- a/Argo/Operators/DecodedOperators.swift
+++ b/Argo/Operators/DecodedOperators.swift
@@ -83,9 +83,9 @@ public func <|><A>(lhs: Decoded<A>, rhs: Decoded<A>) -> Decoded<A> {
   - returns: A value of type `A`
 */
 
-public func ?? <A>(lhs: Decoded<A>, rhs: A) -> A {
+public func ?? <A>(lhs: Decoded<A>, @autoclosure rhs: () -> A) -> A {
   switch lhs {
   case let .Success(x): return x
-  case .Failure: return rhs
+  case .Failure: return rhs()
   }
 }

--- a/Argo/Operators/DecodedOperators.swift
+++ b/Argo/Operators/DecodedOperators.swift
@@ -68,3 +68,24 @@ public func <|><A>(lhs: Decoded<A>, rhs: Decoded<A>) -> Decoded<A> {
   }
   return rhs
 }
+
+// MARK: Failure coalescing operator
+
+/**
+  return the unwrapped value of the `Decoded` value on the left if it is `.Success`, otherwise return the default on the right
+
+  - If the left hand side is successful, this will return the unwrapped value from the left hand side argument
+  - If the left hand side is unsuccesful, this will return the default value on the right hand side
+
+  - parameter lhs: A value of type `Decoded<A>`
+  - parameter rhs: A value of type `A`
+
+  - returns: A value of type `A`
+*/
+
+public func ?? <A>(lhs: Decoded<A>, rhs: A) -> A {
+  switch lhs {
+  case let .Success(x): return x
+  case .Failure: return rhs
+  }
+}

--- a/Argo/Operators/DecodedOperators.swift
+++ b/Argo/Operators/DecodedOperators.swift
@@ -78,7 +78,7 @@ public func <|><A>(lhs: Decoded<A>, rhs: Decoded<A>) -> Decoded<A> {
   - If the left hand side is unsuccesful, this will return the default value on the right hand side
 
   - parameter lhs: A value of type `Decoded<A>`
-  - parameter rhs: A value of type `A`
+  - parameter rhs: An autoclosure returning a value of type `A`
 
   - returns: A value of type `A`
 */

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -90,10 +90,3 @@ public extension Decoded {
     }
   }
 }
-
-public func ?? <T>(lhs: Decoded<T>, rhs: T) -> T {
-  switch lhs {
-  case let .Success(x): return x
-  case .Failure: return rhs
-  }
-}

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -90,3 +90,10 @@ public extension Decoded {
     }
   }
 }
+
+public func ?? <T>(lhs: Decoded<T>, rhs: T) -> T {
+  switch lhs {
+  case let .Success(x): return x
+  case .Failure: return rhs
+  }
+}


### PR DESCRIPTION
- `??` works the same way that you'd expect. If the `lhs` argument is a
   `.Failure` case, it returns the default value on the right. If it's a
  `.Success`, it returns the unwrapped value.
 - `catDecoded` takes an array of `Decoded<T>` objects, and returns the
   unwrapped `.Success` values, discarding any `.Failure` values. The
   same function is implemented for dictionaries.

This isn't needed in our default API, but enough people are looking for
this kind of functionality that it makes sense for us to provide it
officially.