### PR TITLE
Standardize generic types and variables

### DIFF
--- a/Argo/Extensions/Dictionary.swift
+++ b/Argo/Extensions/Dictionary.swift
@@ -1,5 +1,5 @@
 // pure merge for Dictionaries
-func + <T, V>(var lhs: [T: V], rhs: [T: V]) -> [T: V] {
+func + <T, U>(var lhs: [T: U], rhs: [T: U]) -> [T: U] {
   for (key, val) in rhs {
     lhs[key] = val
   }
@@ -8,11 +8,11 @@ func + <T, V>(var lhs: [T: V], rhs: [T: V]) -> [T: V] {
 }
 
 extension Dictionary {
-  func map<A>(f: Value -> A) -> [Key: A] {
+  func map<T>(f: Value -> T) -> [Key: T] {
     return self.reduce([:]) { $0 + [$1.0: f($1.1)] }
   }
 }
 
-func <^> <A, B, C>(f: A -> B, a: [C: A]) -> [C: B] {
-  return a.map(f)
+func <^> <T, U, V>(f: T -> U, x: [V: T]) -> [V: U] {
+  return x.map(f)
 }

--- a/Argo/Functions/curry.swift
+++ b/Argo/Functions/curry.swift
@@ -1,3 +1,3 @@
-func curry<A, B, C>(f : (A, B) -> C) -> A -> B -> C {
-  return { a in { b in f(a, b) } }
+func curry<T, U, V>(f : (T, U) -> V) -> T -> U -> V {
+  return { x in { y in f(x, y) } }
 }

--- a/Argo/Operators/DecodedOperators.swift
+++ b/Argo/Operators/DecodedOperators.swift
@@ -6,13 +6,13 @@
   - If the value is a failing case (`.TypeMismatch`, `.MissingKey`), the function will not be evaluated and this will return the value
   - If the value is `.Success`, the function will be applied to the unwrapped value
 
-  - parameter a: A value of type `Decoded<A>`
-  - parameter f: A transformation function from type `A` to type `Decoded<B>`
+  - parameter x: A value of type `Decoded<T>`
+  - parameter f: A transformation function from type `T` to type `Decoded<U>`
 
-  - returns: A value of type `Decoded<B>`
+  - returns: A value of type `Decoded<U>`
 */
-public func >>- <A, B>(a: Decoded<A>, f: A -> Decoded<B>) -> Decoded<B> {
-  return a.flatMap(f)
+public func >>- <T, U>(x: Decoded<T>, f: T -> Decoded<U>) -> Decoded<U> {
+  return x.flatMap(f)
 }
 
 /**
@@ -21,13 +21,13 @@ public func >>- <A, B>(a: Decoded<A>, f: A -> Decoded<B>) -> Decoded<B> {
   - If the value is is a failing case (`.TypeMismatch`, `.MissingKey`), the function will not be evaluated and this will return the value
   - If the value is `.Success`, the function will be applied to the unwrapped value
 
-  - parameter f: A transformation function from type `A` to type `B`
-  - parameter a: A value of type `Decoded<A>`
+  - parameter f: A transformation function from type `T` to type `U`
+  - parameter x: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<B>`
+  - returns: A value of type `Decoded<U>`
 */
-public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
-  return a.map(f)
+public func <^> <T, U>(f: T -> U, x: Decoded<T>) -> Decoded<U> {
+  return x.map(f)
 }
 
 /**
@@ -37,13 +37,13 @@ public func <^> <A, B>(f: A -> B, a: Decoded<A>) -> Decoded<B> {
   - If the function is a `.Success` case and the value is a failure case, this will return the value
   - If both self and the function are `.Success`, the function will be applied to the unwrapped value
 
-  - parameter f: A `Decoded` transformation function from type `A` to type `B`
-  - parameter a: A value of type `Decoded<A>`
+  - parameter f: A `Decoded` transformation function from type `T` to type `U`
+  - parameter x: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<B>`
+  - returns: A value of type `Decoded<U>`
 */
-public func <*> <A, B>(f: Decoded<A -> B>, a: Decoded<A>) -> Decoded<B> {
-  return a.apply(f)
+public func <*> <T, U>(f: Decoded<T -> U>, x: Decoded<T>) -> Decoded<U> {
+  return x.apply(f)
 }
 
 // MARK: Alternative operator
@@ -54,15 +54,15 @@ public func <*> <A, B>(f: Decoded<A -> B>, a: Decoded<A>) -> Decoded<B> {
   - If the left hand side is successful, this will return the left hand side
   - If the left hand side is unsuccesful, this will return the right hand side
 
-  - parameter lhs: A value of type `Decoded<A>`
-  - parameter rhs: A value of type `Decoded<A>`
+  - parameter lhs: A value of type `Decoded<T>`
+  - parameter rhs: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<A>`
+  - returns: A value of type `Decoded<T>`
 */
 
 infix operator <|> { associativity left precedence 140 }
 
-public func <|><A>(lhs: Decoded<A>, rhs: Decoded<A>) -> Decoded<A> {
+public func <|><T>(lhs: Decoded<T>, rhs: Decoded<T>) -> Decoded<T> {
   if case .Success = lhs {
     return lhs
   }
@@ -77,13 +77,13 @@ public func <|><A>(lhs: Decoded<A>, rhs: Decoded<A>) -> Decoded<A> {
   - If the left hand side is successful, this will return the unwrapped value from the left hand side argument
   - If the left hand side is unsuccesful, this will return the default value on the right hand side
 
-  - parameter lhs: A value of type `Decoded<A>`
-  - parameter rhs: An autoclosure returning a value of type `A`
+  - parameter lhs: A value of type `Decoded<T>`
+  - parameter rhs: An autoclosure returning a value of type `T`
 
-  - returns: A value of type `A`
+  - returns: A value of type `T`
 */
 
-public func ?? <A>(lhs: Decoded<A>, @autoclosure rhs: () -> A) -> A {
+public func ?? <T>(lhs: Decoded<T>, @autoclosure rhs: () -> T) -> T {
   switch lhs {
   case let .Success(x): return x
   case .Failure: return rhs()

--- a/Argo/Operators/OptionalOperators.swift
+++ b/Argo/Operators/OptionalOperators.swift
@@ -1,43 +1,43 @@
 // MARK: Values
 
 // Pull value from JSON
-public func <| <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> A? {
+public func <| <T where T: Decodable, T == T.DecodedType>(json: JSON, key: String) -> T? {
   return json <| [key]
 }
 
 // Pull optional value from JSON
-public func <|? <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> A?? {
+public func <|? <T where T: Decodable, T == T.DecodedType>(json: JSON, key: String) -> T?? {
   return json <| [key]
 }
 
 // Pull embedded value from JSON
-public func <| <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A? {
+public func <| <T where T: Decodable, T == T.DecodedType>(json: JSON, keys: [String]) -> T? {
   return (json <| keys).value
 }
 
 // Pull embedded optional value from JSON
-public func <|? <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> A?? {
+public func <|? <T where T: Decodable, T == T.DecodedType>(json: JSON, keys: [String]) -> T?? {
   return (json <|? keys).value
 }
 
 // MARK: Arrays
 
 // Pull array from JSON
-public func <|| <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> [A]? {
+public func <|| <T where T: Decodable, T == T.DecodedType>(json: JSON, key: String) -> [T]? {
   return json <|| [key]
 }
 
 // Pull optional array from JSON
-public func <||? <A where A: Decodable, A == A.DecodedType>(json: JSON, key: String) -> [A]?? {
+public func <||? <T where T: Decodable, T == T.DecodedType>(json: JSON, key: String) -> [T]?? {
   return json <||? [key]
 }
 
 // Pull embedded array from JSON
-public func <|| <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> [A]? {
+public func <|| <T where T: Decodable, T == T.DecodedType>(json: JSON, keys: [String]) -> [T]? {
   return (json <|| keys).value
 }
 
 // Pull embedded optional array from JSON
-public func <||? <A where A: Decodable, A == A.DecodedType>(json: JSON, keys: [String]) -> [A]?? {
+public func <||? <T where T: Decodable, T == T.DecodedType>(json: JSON, keys: [String]) -> [T]?? {
   return (json <||? keys).value
 }

--- a/Argo/Types/Decoded.swift
+++ b/Argo/Types/Decoded.swift
@@ -85,8 +85,8 @@ public extension Decoded {
   }
 }
 
-public func pure<A>(a: A) -> Decoded<A> {
-  return .Success(a)
+public func pure<T>(x: T) -> Decoded<T> {
+  return .Success(x)
 }
 
 public extension Decoded {


### PR DESCRIPTION
It seems that Swift is standardizing on T and U for generic parameters
over Haskell's a and b so let's follow that. Use V if you need a third
and S for sequences. Also, let's standardize on math variables x and y.