### PR TITLE
Update errors for RawRepresentable types.

### DIFF
--- a/Argo/Extensions/RawRepresentable.swift
+++ b/Argo/Extensions/RawRepresentable.swift
@@ -1,7 +1,7 @@
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == String {
   static func decode(json: JSON) -> Decoded<Self> {
     switch json {
-    case let .String(s): return self.init(rawValue: s).map(pure) ?? .typeMismatch("String", actual: json)
+    case let .String(s): return self.init(rawValue: s).map(pure) ?? .typeMismatch("\(self)", actual: json)
     default: return .typeMismatch("String", actual: json)
     }
   }
@@ -10,7 +10,7 @@ public extension Decodable where Self.DecodedType == Self, Self: RawRepresentabl
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == Int {
   static func decode(json: JSON) -> Decoded<Self> {
     switch json {
-    case let .Number(n): return self.init(rawValue: n as Int).map(pure) ?? .typeMismatch("Int", actual: json)
+    case let .Number(n): return self.init(rawValue: n as Int).map(pure) ?? .typeMismatch("\(self)", actual: json)
     default: return .typeMismatch("Int", actual: json)
     }
   }

--- a/Argo/Extensions/RawRepresentable.swift
+++ b/Argo/Extensions/RawRepresentable.swift
@@ -1,7 +1,7 @@
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == String {
   static func decode(json: JSON) -> Decoded<Self> {
     switch json {
-    case let .String(s): return .fromOptional(self.init(rawValue: s))
+    case let .String(s): return self.init(rawValue: s).map(pure) ?? .typeMismatch("String", actual: json)
     default: return .typeMismatch("String", actual: json)
     }
   }
@@ -10,7 +10,7 @@ public extension Decodable where Self.DecodedType == Self, Self: RawRepresentabl
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == Int {
   static func decode(json: JSON) -> Decoded<Self> {
     switch json {
-    case let .Number(n): return .fromOptional(self.init(rawValue: n as Int))
+    case let .Number(n): return self.init(rawValue: n as Int).map(pure) ?? .typeMismatch("Int", actual: json)
     default: return .typeMismatch("Int", actual: json)
     }
   }

--- a/Argo/Extensions/RawRepresentable.swift
+++ b/Argo/Extensions/RawRepresentable.swift
@@ -1,7 +1,7 @@
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == String {
   static func decode(json: JSON) -> Decoded<Self> {
     switch json {
-    case let .String(s): return self.init(rawValue: s).map(pure) ?? .typeMismatch("\(self)", actual: json)
+    case let .String(s): return self.init(rawValue: s).map(pure) ?? .typeMismatch("rawValue for \(self)", actual: json)
     default: return .typeMismatch("String", actual: json)
     }
   }
@@ -10,7 +10,7 @@ public extension Decodable where Self.DecodedType == Self, Self: RawRepresentabl
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == Int {
   static func decode(json: JSON) -> Decoded<Self> {
     switch json {
-    case let .Number(n): return self.init(rawValue: n as Int).map(pure) ?? .typeMismatch("\(self)", actual: json)
+    case let .Number(n): return self.init(rawValue: n as Int).map(pure) ?? .typeMismatch("rawValue for \(self)", actual: json)
     default: return .typeMismatch("Int", actual: json)
     }
   }


### PR DESCRIPTION
This aims to close #275.

Using my `Provider` example:

```swift
enum Provider {
  case Facebook = "facebook"
  case GitHub = "github"
  case Twitter = "twitter"
}
```

**Before:**
```
TypeMismatch(Expected .Some(Provider), got .None)
```

**After:**
```
TypeMismatch(Expected Provider, got String(google))
```