### PR TITLE
Add free functions for decoding collections

### DIFF
--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -72,6 +72,10 @@ public extension CollectionType where Generator.Element: Decodable, Generator.El
   }
 }
 
+public func decodeArray<T: Decodable where T.DecodedType == T>(j: JSON) -> Decoded<[T]> {
+  return [T].decode(j)
+}
+
 public extension DictionaryLiteralConvertible where Value: Decodable, Value == Value.DecodedType {
   static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
@@ -79,6 +83,10 @@ public extension DictionaryLiteralConvertible where Value: Decodable, Value == V
     default: return .typeMismatch("Object", actual: j)
     }
   }
+}
+
+public func decodeObject<T: Decodable where T.DecodedType == T>(j: JSON) -> Decoded<[String: T]> {
+  return [String: T].decode(j)
 }
 
 public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {


### PR DESCRIPTION
In Argo 2 we removed the free functions `decodeArray` and `decodeObject`
in favor of adding this functionality to the types themselves. I believe
this was a mistake and would like to reintroduce them to the public API.

My reasoning is this:

Adding `decode` to these types does _not_ make these types conform to
`Decodable`. That's confusing to me (and I'd imagine, other people). The
result of this is that you can't just decode directly to these types,
but instead have to use a special function. In the case of `Array`
that's not a huge deal since we expose an operator (`<||`) for this, but
for decoding objects, it means that users have to specify the actual
type that they'd like to decode. This is weird, since it's the _only_
place in the public API that we don't let users lean on the type system
to do the hard work for them.

I think it makes the most sense to reintroduce these free functions
without actually removing the existing protocol extensions. This will
improve backwards compatibility with Argo 1 and improve what I see as a
deficiency in the current API. In addition, if Swift ever gets the
ability to do conditional protocol conformance, leaving the existing
protocol extensions will make it easy to support that as well.

See #296 for an example of where we've made a user's code worse with the new
API.