### PR TITLE
Add alternative named instance method on Decoded

### DIFF
--- a/Argo/Types/Decoded/Alternative.swift
+++ b/Argo/Types/Decoded/Alternative.swift
@@ -13,8 +13,14 @@
 infix operator <|> { associativity left precedence 140 }
 
 public func <|> <T>(lhs: Decoded<T>, @autoclosure rhs: () -> Decoded<T>) -> Decoded<T> {
-  if case .Success = lhs {
-    return lhs
+  return lhs.or(rhs)
+}
+
+public extension Decoded {
+  func or(@autoclosure other: () -> Decoded<T>) -> Decoded<T> {
+    switch self {
+      case .Success: return self
+      case .Failure: return other()
+    }
   }
-  return rhs()
 }

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -116,6 +116,30 @@ class DecodedTests: XCTestCase {
       XCTFail("Unexpected Error Occurred")
     }
   }
+
+  func testDecodedOrWithSuccess() {
+    let successUser: Decoded<User> = decode(JSONFromFile("user_with_email")!)
+    let failedUser: Decoded<User> = decode(JSONFromFile("user_with_bad_type")!)
+
+    let result = successUser.or(failedUser)
+
+    switch result {
+    case .Success: XCTAssert(result.description == successUser.description)
+    default: XCTFail("Unexpected Case Occurred")
+    }
+  }
+
+  func testDecodedOrWithError() {
+    let successUser: Decoded<User> = decode(JSONFromFile("user_with_email")!)
+    let failedUser: Decoded<User> = decode(JSONFromFile("user_with_bad_type")!)
+
+    let result = failedUser.or(successUser)
+
+    switch result {
+    case .Success: XCTAssert(result.description == successUser.description)
+    default: XCTFail("Unexpected Case Occurred")
+    }
+  }
 }
 
 private struct Dummy: Decodable {


### PR DESCRIPTION
Fixes #307, brings alternative inline with other monadic operators in
Argo.