### PR TITLE
[RFC] Change Argo to lazy parse json

### DIFF
--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum JSON {
-  case Object(() -> [Swift.String: JSON])
-  case Array(() -> [JSON])
+  case Object([Swift.String: LazyJSON])
+  case Array([LazyJSON])
   case String(Swift.String)
   case Number(NSNumber)
   case Null
@@ -11,8 +11,8 @@ public enum JSON {
 public extension JSON {
   static func parse(json: AnyObject) -> JSON {
     switch json {
-    case let v as [AnyObject]: return .Array({ v.map(parse) })
-    case let v as [Swift.String: AnyObject]: return .Object({ v.map(parse) })
+    case let v as [AnyObject]: return .Array(v.map(LazyJSON.init))
+    case let v as [Swift.String: AnyObject]: return .Object(v.map(LazyJSON.init))
     case let v as Swift.String: return .String(v)
     case let v as NSNumber: return .Number(v)
     default: return .Null
@@ -31,8 +31,8 @@ extension JSON: CustomStringConvertible {
     switch self {
     case let .String(v): return "String(\(v))"
     case let .Number(v): return "Number(\(v))"
-    case let .Array(a): return "Array(\(a().description))"
-    case let .Object(o): return "Object(\(o().description))"
+    case let .Array(a): return "Array(\(a.description))"
+    case let .Object(o): return "Object(\(o.description))"
     case .Null: return "Null"
     }
   }
@@ -44,9 +44,33 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
   switch (lhs, rhs) {
   case let (.String(l), .String(r)): return l == r
   case let (.Number(l), .Number(r)): return l == r
-  case let (.Array(l), .Array(r)): return l() == r()
-  case let (.Object(l), .Object(r)): return l() == r()
+  case let (.Array(l), .Array(r)): return l == r
+  case let (.Object(l), .Object(r)): return l == r
   case (.Null, .Null): return true
   default: return false
   }
+}
+
+public final class LazyJSON {
+  private let _value: AnyObject
+
+  public lazy var json: JSON = {
+    return JSON.parse(self._value)
+  }()
+
+  public init(_ value: AnyObject) {
+    _value = value
+  }
+}
+
+extension LazyJSON: CustomStringConvertible {
+  public var description: Swift.String {
+    return self.json.description
+  }
+}
+
+extension LazyJSON: Equatable { }
+
+public func == (lhs: LazyJSON, rhs: LazyJSON) -> Bool {
+  return lhs.json == rhs.json
 }

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum JSON {
-  case Object([Swift.String: JSON])
-  case Array([JSON])
+  case Object([Swift.String: AnyObject])
+  case Array([AnyObject])
   case String(Swift.String)
   case Number(NSNumber)
   case Null
@@ -11,8 +11,8 @@ public enum JSON {
 public extension JSON {
   static func parse(json: AnyObject) -> JSON {
     switch json {
-    case let v as [AnyObject]: return .Array(v.map(parse))
-    case let v as [Swift.String: AnyObject]: return .Object(v.map(parse))
+    case let v as [AnyObject]: return .Array(v)
+    case let v as [Swift.String: AnyObject]: return .Object(v)
     case let v as Swift.String: return .String(v)
     case let v as NSNumber: return .Number(v)
     default: return .Null
@@ -44,8 +44,8 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
   switch (lhs, rhs) {
   case let (.String(l), .String(r)): return l == r
   case let (.Number(l), .Number(r)): return l == r
-  case let (.Array(l), .Array(r)): return l == r
-  case let (.Object(l), .Object(r)): return l == r
+  case let (.Array(l), .Array(r)): return l.map(JSON.parse) == r.map(JSON.parse)
+  case let (.Object(l), .Object(r)): return l.map(JSON.parse) == r.map(JSON.parse)
   case (.Null, .Null): return true
   default: return false
   }

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum JSON {
-  case Object([Swift.String: AnyObject])
-  case Array([AnyObject])
+  case Object(() -> [Swift.String: JSON])
+  case Array(() -> [JSON])
   case String(Swift.String)
   case Number(NSNumber)
   case Null
@@ -11,8 +11,8 @@ public enum JSON {
 public extension JSON {
   static func parse(json: AnyObject) -> JSON {
     switch json {
-    case let v as [AnyObject]: return .Array(v)
-    case let v as [Swift.String: AnyObject]: return .Object(v)
+    case let v as [AnyObject]: return .Array({ v.map(parse) })
+    case let v as [Swift.String: AnyObject]: return .Object({ v.map(parse) })
     case let v as Swift.String: return .String(v)
     case let v as NSNumber: return .Number(v)
     default: return .Null
@@ -31,8 +31,8 @@ extension JSON: CustomStringConvertible {
     switch self {
     case let .String(v): return "String(\(v))"
     case let .Number(v): return "Number(\(v))"
-    case let .Array(a): return "Array(\(a.description))"
-    case let .Object(o): return "Object(\(o.description))"
+    case let .Array(a): return "Array(\(a().description))"
+    case let .Object(o): return "Object(\(o().description))"
     case .Null: return "Null"
     }
   }
@@ -44,8 +44,8 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
   switch (lhs, rhs) {
   case let (.String(l), .String(r)): return l == r
   case let (.Number(l), .Number(r)): return l == r
-  case let (.Array(l), .Array(r)): return l.map(JSON.parse) == r.map(JSON.parse)
-  case let (.Object(l), .Object(r)): return l.map(JSON.parse) == r.map(JSON.parse)
+  case let (.Array(l), .Array(r)): return l() == r()
+  case let (.Object(l), .Object(r)): return l() == r()
   case (.Null, .Null): return true
   default: return false
   }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -66,7 +66,7 @@ public extension Optional where Wrapped: Decodable, Wrapped == Wrapped.DecodedTy
 public extension CollectionType where Generator.Element: Decodable, Generator.Element == Generator.Element.DecodedType {
   static func decode(j: JSON) -> Decoded<[Generator.Element]> {
     switch j {
-    case let .Array(a): return sequence(a.map(Generator.Element.decode))
+    case let .Array(a): return sequence(a.map(JSON.parse).map(Generator.Element.decode))
     default: return .typeMismatch("Array", actual: j)
     }
   }
@@ -79,7 +79,7 @@ public func decodeArray<T: Decodable where T.DecodedType == T>(j: JSON) -> Decod
 public extension DictionaryLiteralConvertible where Value: Decodable, Value == Value.DecodedType {
   static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
-    case let .Object(o): return sequence(Value.decode <^> o)
+    case let .Object(o): return sequence(Value.decode <^> o.map(JSON.parse))
     default: return .typeMismatch("Object", actual: j)
     }
   }
@@ -91,7 +91,7 @@ public func decodeObject<T: Decodable where T.DecodedType == T>(j: JSON) -> Deco
 
 public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
-  case let .Object(o): return guardNull(key, j: o[key] ?? .Null)
+  case let .Object(o): return guardNull(key, j: o[key].map(JSON.parse) ?? .Null)
   default: return .typeMismatch("Object", actual: json)
   }
 }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -66,7 +66,7 @@ public extension Optional where Wrapped: Decodable, Wrapped == Wrapped.DecodedTy
 public extension CollectionType where Generator.Element: Decodable, Generator.Element == Generator.Element.DecodedType {
   static func decode(j: JSON) -> Decoded<[Generator.Element]> {
     switch j {
-    case let .Array(a): return sequence(a().map(Generator.Element.decode))
+    case let .Array(a): return sequence(a.map { Generator.Element.decode($0.json) })
     default: return .typeMismatch("Array", actual: j)
     }
   }
@@ -79,7 +79,7 @@ public func decodeArray<T: Decodable where T.DecodedType == T>(j: JSON) -> Decod
 public extension DictionaryLiteralConvertible where Value: Decodable, Value == Value.DecodedType {
   static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
-    case let .Object(o): return sequence(Value.decode <^> o())
+    case let .Object(o): return sequence({ Value.decode($0.json) } <^> o)
     default: return .typeMismatch("Object", actual: j)
     }
   }
@@ -91,7 +91,7 @@ public func decodeObject<T: Decodable where T.DecodedType == T>(j: JSON) -> Deco
 
 public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
-  case let .Object(o): return guardNull(key, j: o()[key] ?? .Null)
+  case let .Object(o): return guardNull(key, j: o[key]?.json ?? .Null)
   default: return .typeMismatch("Object", actual: json)
   }
 }

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -66,7 +66,7 @@ public extension Optional where Wrapped: Decodable, Wrapped == Wrapped.DecodedTy
 public extension CollectionType where Generator.Element: Decodable, Generator.Element == Generator.Element.DecodedType {
   static func decode(j: JSON) -> Decoded<[Generator.Element]> {
     switch j {
-    case let .Array(a): return sequence(a.map(JSON.parse).map(Generator.Element.decode))
+    case let .Array(a): return sequence(a().map(Generator.Element.decode))
     default: return .typeMismatch("Array", actual: j)
     }
   }
@@ -79,7 +79,7 @@ public func decodeArray<T: Decodable where T.DecodedType == T>(j: JSON) -> Decod
 public extension DictionaryLiteralConvertible where Value: Decodable, Value == Value.DecodedType {
   static func decode(j: JSON) -> Decoded<[String: Value]> {
     switch j {
-    case let .Object(o): return sequence(Value.decode <^> o.map(JSON.parse))
+    case let .Object(o): return sequence(Value.decode <^> o())
     default: return .typeMismatch("Object", actual: j)
     }
   }
@@ -91,7 +91,7 @@ public func decodeObject<T: Decodable where T.DecodedType == T>(j: JSON) -> Deco
 
 public func decodedJSON(json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
-  case let .Object(o): return guardNull(key, j: o[key].map(JSON.parse) ?? .Null)
+  case let .Object(o): return guardNull(key, j: o()[key] ?? .Null)
   default: return .typeMismatch("Object", actual: json)
   }
 }

--- a/ArgoTests/Tests/RawRepresentableTests.swift
+++ b/ArgoTests/Tests/RawRepresentableTests.swift
@@ -16,10 +16,10 @@ extension TestRawInt: Decodable { }
 
 class RawRepresentable: XCTestCase {
   func testStringEnum() {
-    let json = JSON.Object({[
-      "string": JSON.String("CoolString"),
-      "another": JSON.String("NotCoolStringBro")
-      ]})
+    let json = JSON.Object([
+      "string": LazyJSON("CoolString"),
+      "another": LazyJSON("NotCoolStringBro")
+      ])
 
     let string: TestRawString? = json <| "string"
     let another: TestRawString? = json <| "another"
@@ -28,10 +28,10 @@ class RawRepresentable: XCTestCase {
   }
 
   func testIntEnum() {
-    let json = JSON.Object({[
-      "zero": JSON.Number(0),
-      "one": JSON.Number(1)
-      ]})
+    let json = JSON.Object([
+      "zero": LazyJSON(0),
+      "one": LazyJSON(1)
+      ])
 
     let zero: TestRawInt? = json <| "zero"
     let one: TestRawInt? = json <| "one"

--- a/ArgoTests/Tests/RawRepresentableTests.swift
+++ b/ArgoTests/Tests/RawRepresentableTests.swift
@@ -16,10 +16,10 @@ extension TestRawInt: Decodable { }
 
 class RawRepresentable: XCTestCase {
   func testStringEnum() {
-    let json = JSON.Object([
-      "string": "CoolString",
-      "another": "NotCoolStringBro"
-      ])
+    let json = JSON.Object({[
+      "string": JSON.String("CoolString"),
+      "another": JSON.String("NotCoolStringBro")
+      ]})
 
     let string: TestRawString? = json <| "string"
     let another: TestRawString? = json <| "another"
@@ -28,10 +28,10 @@ class RawRepresentable: XCTestCase {
   }
 
   func testIntEnum() {
-    let json = JSON.Object([
-      "zero": 0,
-      "one": 1
-      ])
+    let json = JSON.Object({[
+      "zero": JSON.Number(0),
+      "one": JSON.Number(1)
+      ]})
 
     let zero: TestRawInt? = json <| "zero"
     let one: TestRawInt? = json <| "one"

--- a/ArgoTests/Tests/RawRepresentableTests.swift
+++ b/ArgoTests/Tests/RawRepresentableTests.swift
@@ -17,8 +17,8 @@ extension TestRawInt: Decodable { }
 class RawRepresentable: XCTestCase {
   func testStringEnum() {
     let json = JSON.Object([
-      "string": JSON.String("CoolString"),
-      "another": JSON.String("NotCoolStringBro")
+      "string": "CoolString",
+      "another": "NotCoolStringBro"
       ])
 
     let string: TestRawString? = json <| "string"
@@ -29,8 +29,8 @@ class RawRepresentable: XCTestCase {
 
   func testIntEnum() {
     let json = JSON.Object([
-      "zero": JSON.Number(0),
-      "one": JSON.Number(1)
+      "zero": 0,
+      "one": 1
       ])
 
     let zero: TestRawInt? = json <| "zero"


### PR DESCRIPTION
To lazily parse json we change the `JSON` type to not be recursive.
Arrays and Objects no longer parse their values when the json is parsed
into a `JSON` value. Instead, we call parse on the values just before
they are decoded. The major pitfall here is that there is duplicate
parsing since previously parsed json will have to be parsed again if
used again.

Looking at the performance tests: Before this change, parsing took about
137ms and decoding took 37ms totalling 174ms. After this change, parsing
took 0ms (this makes sense) and decoding took 100ms totalling 100ms. So
we see that decoding took longer since we moved the parsing into it, but
we see the overall time is shorter and even shorter than just parsing
was.

This is an experimental attempt to implement #185 and might hopefully solve or improved #295 