### PR TITLE
Improve bin/test

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -8,3 +8,24 @@ xcrun xcodebuild \
   test \
   | xcpretty --color
 
+xcrun xcodebuild \
+  -workspace Argo.xcworkspace \
+  -scheme Argo-iOS \
+  -destination "platform=iOS Simulator,name=iPhone 6" \
+  test \
+  | xcpretty --color
+
+xcrun xcodebuild \
+  -workspace Argo.xcworkspace \
+  -scheme Argo-watchOS \
+  -destination "generic/platform=watchOS" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGN_IDENTITY="" \
+  | xcpretty --color
+
+xcrun xcodebuild \
+  -workspace Argo.xcworkspace \
+  -scheme Argo-tvOS \
+  -destination "platform=tvOS Simulator,name=Apple TV 1080p" \
+  test \
+  | xcpretty --color

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.0"
+    version: "7.1"
   environment:
     XCODE_SCHEME: nonce
     XCODE_WORKSPACE: nonce.xcworkspace


### PR DESCRIPTION
Previously we were _only_ running tests on CI against the mac target.
This seems short sighted. Instead, lets make sure we can build for all
of our supported platforms, running the tests on the platforms that
support it.