### PR TITLE
Remove reduce usage for better performance

### DIFF
--- a/Argo/Extensions/Dictionary.swift
+++ b/Argo/Extensions/Dictionary.swift
@@ -9,7 +9,13 @@ func + <T, U>(var lhs: [T: U], rhs: [T: U]) -> [T: U] {
 
 extension Dictionary {
   func map<T>(@noescape f: Value -> T) -> [Key: T] {
-    return self.reduce([:]) { $0 + [$1.0: f($1.1)] }
+    var accum = Dictionary<Key, T>(minimumCapacity: self.count)
+    
+    for (key, value) in self {
+      accum[key] = f(value)
+    }
+    
+    return accum
   }
 }
 

--- a/Argo/Extensions/Dictionary.swift
+++ b/Argo/Extensions/Dictionary.swift
@@ -10,11 +10,11 @@ func + <T, U>(var lhs: [T: U], rhs: [T: U]) -> [T: U] {
 extension Dictionary {
   func map<T>(@noescape f: Value -> T) -> [Key: T] {
     var accum = Dictionary<Key, T>(minimumCapacity: self.count)
-    
+
     for (key, value) in self {
       accum[key] = f(value)
     }
-    
+
     return accum
   }
 }

--- a/Argo/Functions/catDecoded.swift
+++ b/Argo/Functions/catDecoded.swift
@@ -15,8 +15,8 @@ public func catDecoded<T>(xs: [Decoded<T>]) -> [T] {
 public func catDecoded<T>(xs: [String: Decoded<T>]) -> [String: T] {
   var accum = Dictionary<String, T>(minimumCapacity: xs.count)
 
-  for (key, decodedValue) in xs {
-    switch decodedValue {
+  for (key, x) in xs {
+    switch x {
     case let .Success(value): accum[key] = value
     case .Failure: continue
     }

--- a/Argo/Functions/catDecoded.swift
+++ b/Argo/Functions/catDecoded.swift
@@ -1,11 +1,26 @@
 public func catDecoded<T>(xs: [Decoded<T>]) -> [T] {
-  return xs.reduce([]) { accum, elem in
-    elem.map { accum + [$0] } ?? accum
+  var accum: [T] = []
+  accum.reserveCapacity(xs.count)
+  
+  for x in xs {
+    switch x {
+    case let .Success(value): accum.append(value)
+    case .Failure: continue
+    }
   }
+  
+  return accum
 }
 
 public func catDecoded<T>(xs: [String: Decoded<T>]) -> [String: T] {
-  return xs.reduce([:]) { accum, elem in
-    elem.1.map { accum + [elem.0: $0] } ?? accum
+  var accum = Dictionary<String, T>(minimumCapacity: xs.count)
+  
+  for (key, decodedValue) in xs {
+    switch decodedValue {
+    case let .Success(value): accum[key] = value
+    case .Failure: continue
+    }
   }
+  
+  return accum
 }

--- a/Argo/Functions/catDecoded.swift
+++ b/Argo/Functions/catDecoded.swift
@@ -1,26 +1,26 @@
 public func catDecoded<T>(xs: [Decoded<T>]) -> [T] {
   var accum: [T] = []
   accum.reserveCapacity(xs.count)
-  
+
   for x in xs {
     switch x {
     case let .Success(value): accum.append(value)
     case .Failure: continue
     }
   }
-  
+
   return accum
 }
 
 public func catDecoded<T>(xs: [String: Decoded<T>]) -> [String: T] {
   var accum = Dictionary<String, T>(minimumCapacity: xs.count)
-  
+
   for (key, decodedValue) in xs {
     switch decodedValue {
     case let .Success(value): accum[key] = value
     case .Failure: continue
     }
   }
-  
+
   return accum
 }

--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -16,7 +16,7 @@ public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
 
 public func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
   var accum: [String: T] = [:]
-  
+
   for (key, value) in xs {
     switch value {
     case let .Success(unwrapped):

--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -2,12 +2,10 @@ public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
   var accum: [T] = []
   accum.reserveCapacity(xs.count)
 
-  for elem in xs {
-    switch elem {
-    case let .Success(value):
-      accum.append(value)
-    case let .Failure(error):
-      return .Failure(error)
+  for x in xs {
+    switch x {
+    case let .Success(value): accum.append(value)
+    case let .Failure(error): return .Failure(error)
     }
   }
 
@@ -15,14 +13,12 @@ public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
 }
 
 public func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
-  var accum: [String: T] = [:]
+  var accum = Dictionary<String, T>(minimumCapacity: xs.count)
 
-  for (key, value) in xs {
-    switch value {
-    case let .Success(unwrapped):
-      accum[key] = unwrapped
-    case let .Failure(error):
-      return .Failure(error)
+  for (key, x) in xs {
+    switch x {
+    case let .Success(value): accum[key] = value
+    case let .Failure(error): return .Failure(error)
     }
   }
 

--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -1,7 +1,7 @@
 public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
   var accum: [T] = []
   accum.reserveCapacity(xs.count)
-  
+
   for elem in xs {
     switch elem {
     case let .Success(value):
@@ -10,7 +10,7 @@ public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
       return .Failure(error)
     }
   }
-  
+
   return pure(accum)
 }
 
@@ -25,6 +25,6 @@ public func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
       return .Failure(error)
     }
   }
-  
+
   return pure(accum)
 }

--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -1,11 +1,30 @@
 public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
-  return xs.reduce(pure([])) { accum, elem in
-    curry(+) <^> accum <*> ({ [$0] } <^> elem)
+  var accum: [T] = []
+  accum.reserveCapacity(xs.count)
+  
+  for elem in xs {
+    switch elem {
+    case let .Success(value):
+      accum.append(value)
+    case let .Failure(error):
+      return .Failure(error)
+    }
   }
+  
+  return pure(accum)
 }
 
 public func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
-  return xs.reduce(pure([:])) { accum, elem in
-    curry(+) <^> accum <*> ({ [elem.0: $0] } <^> elem.1)
+  var accum: [String: T] = [:]
+  
+  for (key, value) in xs {
+    switch value {
+    case let .Success(unwrapped):
+      accum[key] = unwrapped
+    case let .Failure(error):
+      return .Failure(error)
+    }
   }
+  
+  return pure(accum)
 }

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -18,4 +18,11 @@ class PerformanceTests: XCTestCase {
       [TestModel].decode(j)
     }
   }
+
+  func testBigDataDecodesCorrectly() {
+    let json: AnyObject = JSONFromFile("big_data")!
+    let j = JSON.parse(json)
+    let models = [TestModel].decode(j)
+    XCTAssertEqual(models.value!.count, 10_000, "Decoded big_data should have 10_000 results.")
+  }
 }

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -13,7 +13,7 @@ class PerformanceTests: XCTestCase {
   func testDecodePerformance() {
     let json: AnyObject = JSONFromFile("big_data")!
     let j = JSON.parse(json)
-    
+
     measureBlock {
       [TestModel].decode(j)
     }

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -13,9 +13,9 @@ class PerformanceTests: XCTestCase {
   func testDecodePerformance() {
     let json: AnyObject = JSONFromFile("big_data")!
     let j = JSON.parse(json)
-
+    
     measureBlock {
-      j <|| "types" as Decoded<[TestModel]>
+      [TestModel].decode(j)
     }
   }
 }


### PR DESCRIPTION
Argo’s performance is quadratic over the size of the collection being decoded, due to the use of reduce ([AirspeedVelocity article](http://airspeedvelocity.net/2015/08/03/arrays-linked-lists-and-performance/)). This PR removes most usages of `reduce` in exchange for a `for` loop of the same functionality. This improves the performance of decoding an array of over 9000 simple models on an iPhone 4S by ~2600% (76.4s to 2.9s). See #295 for my analysis and evolution of this code.