### PR TITLE
Use an autoclosure for the rhs of <|>

### DIFF
--- a/Argo/Types/Decoded/Alternative.swift
+++ b/Argo/Types/Decoded/Alternative.swift
@@ -12,9 +12,9 @@
 
 infix operator <|> { associativity left precedence 140 }
 
-public func <|> <T>(lhs: Decoded<T>, rhs: Decoded<T>) -> Decoded<T> {
+public func <|> <T>(lhs: Decoded<T>, @autoclosure rhs: () -> Decoded<T>) -> Decoded<T> {
   if case .Success = lhs {
     return lhs
   }
-  return rhs
+  return rhs()
 }


### PR DESCRIPTION
The nil coalescer operator already uses an autoclosure for the rhs
argument, so it makes sense to follow suit here.

Fixes #289