### PR TITLE
Fix links in Basic-Usage.md

### DIFF
--- a/Documentation/Basic-Usage.md
+++ b/Documentation/Basic-Usage.md
@@ -79,12 +79,11 @@ expectations, Argo will skip the `init` call and return a special failure state.
 
 Now, we make `User` conform to `Decodable` and implement the required `decode`
 function. We will implement this function by using some [functional
-concepts](functional_concepts),
+concepts](Functional-Concepts.md),
 specifically the `map` (`<^>`) and `apply` (`<*>`) operators, to conditionally
 pass the required parameters to the curried init function. The common pattern
 will look like this:
 
-[functional_concepts]: https://github.com/thoughtbot/Argo/blob/master/Documentation/Functional-Concepts.md
 
 ```swift
   static func decode(json: JSON) -> Decoded<DecodedType> {
@@ -186,7 +185,4 @@ properties in your model, and then the Swift compiler will infer the types that
 need to be sent to the curried `decode` function and therefore the types that
 need to be found in the JSON structure.
 
-For more Argo usage examples, see our [test suite](test_suite).
-
-
-[test_suite]: https://github.com/thoughtbot/Argo/tree/master/ArgoTests
+For more Argo usage examples, see our [test suite](../ArgoTests).


### PR DESCRIPTION
Hi Thoughtbot team,
I found two unavailable links in Basic-Usage.md file, so I fixed them.

- Fixed the link to Functional-Concepts.md.
- Fixed the link to ArgoTests directory.

Since these links point to files in the same repository, relative references are used instead of absolute references.

It would be great if you could review this PR, and merge it if it's good. Thanks!