### PR TITLE
Make DecodeError Hashable

### DIFF
--- a/Argo/Types/DecodeError.swift
+++ b/Argo/Types/DecodeError.swift
@@ -13,3 +13,32 @@ extension DecodeError: CustomStringConvertible {
     }
   }
 }
+
+extension DecodeError: Hashable {
+  public var hashValue: Int {
+    switch self {
+    case let .TypeMismatch(expected: expected, actual: actual):
+      return expected.hashValue ^ actual.hashValue
+    case let .MissingKey(string):
+      return string.hashValue
+    case let .Custom(string):
+      return string.hashValue
+    }
+  }
+}
+
+public func == (lhs: DecodeError, rhs: DecodeError) -> Bool {
+  switch (lhs, rhs) {
+  case let (.TypeMismatch(expected: expected1, actual: actual1), .TypeMismatch(expected: expected2, actual: actual2)):
+    return expected1 == expected2 && actual1 == actual2
+
+  case let (.MissingKey(string1), .MissingKey(string2)):
+    return string1 == string2
+
+  case let (.Custom(string1), .Custom(string2)):
+    return string1 == string2
+
+  default:
+    return false
+  }
+}


### PR DESCRIPTION
I wanted this in https://github.com/mdiep/Tentacle/pull/10 so that I can (1) make my own `ErrorType`, which has a `DecodeError` in one case, `Hashable` and (2) test that certain APIs return the correct error.

Let me know if you'd like any changes. :smile: