### PR TITLE
Refactor loops to use `for case` & `if case` syntax

### DIFF
--- a/Argo/Functions/catDecoded.swift
+++ b/Argo/Functions/catDecoded.swift
@@ -2,11 +2,8 @@ public func catDecoded<T>(xs: [Decoded<T>]) -> [T] {
   var accum: [T] = []
   accum.reserveCapacity(xs.count)
 
-  for x in xs {
-    switch x {
-    case let .Success(value): accum.append(value)
-    case .Failure: continue
-    }
+  for case let .Success(value) in xs {
+    accum.append(value)
   }
 
   return accum
@@ -16,10 +13,7 @@ public func catDecoded<T>(xs: [String: Decoded<T>]) -> [String: T] {
   var accum = Dictionary<String, T>(minimumCapacity: xs.count)
 
   for (key, x) in xs {
-    switch x {
-    case let .Success(value): accum[key] = value
-    case .Failure: continue
-    }
+    if case let .Success(value) = x { accum[key] = value }
   }
 
   return accum


### PR DESCRIPTION
The catDecoded functions ignore the `Failure` case, so we don’t need to
pattern match for `Failure`.