### PR TITLE
Use an initializer instead of a factory for JSON

### DIFF
--- a/Argo/Functions/decode.swift
+++ b/Argo/Functions/decode.swift
@@ -22,7 +22,7 @@
   - returns: A `Decoded<T>` value where `T` is `Decodable`
 */
 public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> Decoded<T> {
-  return T.decode(JSON.parse(object))
+  return T.decode(JSON(object))
 }
 
 /**
@@ -50,7 +50,7 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> 
   - returns: A `Decoded<[T]>` value where `T` is `Decodable`
 */
 public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> Decoded<[T]> {
-  return Array<T>.decode(JSON.parse(object))
+  return Array<T>.decode(JSON(object))
 }
 
 /**
@@ -137,7 +137,7 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> 
   - returns: A `Decoded<T>` value where `T` is `Decodable`
 */
 public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> Decoded<T> {
-  return JSON.parse(object) <| rootKey
+  return JSON(object) <| rootKey
 }
 
 /**
@@ -168,7 +168,7 @@ public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: St
   - returns: A `Decoded<[T]>` value where `T` is `Decodable`
 */
 public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> Decoded<[T]> {
-  return JSON.parse(object) <|| rootKey
+  return JSON(object) <|| rootKey
 }
 
 /**

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -20,13 +20,23 @@ public extension JSON {
 
     - returns: An instance of the `JSON` tree structure
   */
-  static func parse(json: AnyObject) -> JSON {
+  init(_ json: AnyObject) {
     switch json {
-    case let v as [AnyObject]: return .Array(v.map(parse))
-    case let v as [Swift.String: AnyObject]: return .Object(v.map(parse))
-    case let v as Swift.String: return .String(v)
-    case let v as NSNumber: return .Number(v)
-    default: return .Null
+
+    case let v as [AnyObject]:
+      self = .Array(v.map(JSON.init))
+
+    case let v as [Swift.String: AnyObject]:
+      self = .Object(v.map(JSON.init))
+
+    case let v as Swift.String:
+      self = .String(v)
+
+    case let v as NSNumber:
+      self = .Number(v)
+
+    default:
+      self = .Null
     }
   }
 }

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -17,8 +17,6 @@ public extension JSON {
     `NSJSONSerialization`) to the strongly typed `JSON` tree structure.
 
     - parameter json: A loosely typed object
-
-    - returns: An instance of the `JSON` tree structure
   */
   init(_ json: AnyObject) {
     switch json {

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -82,3 +82,12 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
   default: return false
   }
 }
+
+/// MARK: Deprecations
+
+extension JSON {
+  @available(*, deprecated=3.0, renamed="init")
+  static func parse(json: AnyObject) -> JSON {
+    return JSON(json)
+  }
+}

--- a/ArgoTests/Tests/EquatableTests.swift
+++ b/ArgoTests/Tests/EquatableTests.swift
@@ -3,15 +3,15 @@ import Argo
 
 class EquatableTests: XCTestCase {
   func testEqualJSONObjects() {
-    let json = JSONFromFile("types").map(JSON.parse)
-    let anotherParsed = JSONFromFile("types").map(JSON.parse)
+    let json = JSONFromFile("types").map(JSON.init)
+    let anotherParsed = JSONFromFile("types").map(JSON.init)
 
     XCTAssertEqual(json!, anotherParsed!)
   }
 
   func testNotEqualJSONObjects() {
-    let json = JSONFromFile("types").map(JSON.parse)
-    let anotherJSON = JSONFromFile("types_fail_embedded").map(JSON.parse)
+    let json = JSONFromFile("types").map(JSON.init)
+    let anotherJSON = JSONFromFile("types_fail_embedded").map(JSON.init)
 
     XCTAssertNotEqual(json!, anotherJSON!)
   }

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -28,8 +28,8 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingJSONWithRootArray() {
-    let expected = JSON.parse([["title": "Foo", "age": 21], ["title": "Bar", "age": 32]])
-    let json = JSONFromFile("root_array").map(JSON.parse)
+    let expected = JSON([["title": "Foo", "age": 21], ["title": "Bar", "age": 32]])
+    let json = JSONFromFile("root_array").map(JSON.init)
 
     XCTAssert(.Some(expected) == json)
   }

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -6,13 +6,13 @@ class PerformanceTests: XCTestCase {
     let json: AnyObject = JSONFromFile("big_data")!
 
     measureBlock {
-      JSON.parse(json)
+      _ = JSON(json)
     }
   }
 
   func testDecodePerformance() {
     let json: AnyObject = JSONFromFile("big_data")!
-    let j = JSON.parse(json)
+    let j = JSON(json)
 
     measureBlock {
       [TestModel].decode(j)
@@ -21,7 +21,7 @@ class PerformanceTests: XCTestCase {
 
   func testBigDataDecodesCorrectly() {
     let json: AnyObject = JSONFromFile("big_data")!
-    let j = JSON.parse(json)
+    let j = JSON(json)
     let models = [TestModel].decode(j)
     XCTAssertEqual(models.value!.count, 10_000, "Decoded big_data should have 10_000 results.")
   }

--- a/Documentation/Decode-Root-Keys.md
+++ b/Documentation/Decode-Root-Keys.md
@@ -14,13 +14,13 @@ JSON for the model is embedded within a root key:
 }
 ```
 
-In this case, you can't use the global `decode` function because it assumes the
-object you're trying to decode is at the root level. To get around this, first
-parse the `AnyObject` into a `JSON` type, then use the `<|` operator to pull
-out the object and decode it into its model.
+In this case, you can't use the global `decode` function because it assumes
+the object you're trying to decode is at the root level. To get around this,
+first transform the `AnyObject` into a `JSON` type, then use the `<|` operator
+to pull out the object and decode it into its model.
 
 ```swift
-let json = JSON.parse(anyObject)
+let json = JSON(anyObject)
 
 let user: Decoded<User> = json <| "user"
 // or


### PR DESCRIPTION
Previously, we were using a static func here because we needed to recursively
pass it during initial parsing. However, since we can now pass the initializer,
I think it makes sense to simplify the API by directly using an initializer.