### PR TITLE
Improve the API for root key decoding

### DIFF
--- a/Argo/Functions/decode.swift
+++ b/Argo/Functions/decode.swift
@@ -125,18 +125,18 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> 
   ```
   do {
     let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: Decoded<String> = decodeWithRootKey("value", object)
+    let str: Decoded<String> = decode(object, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter rootKey: The root key that contains the object to decode
   - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<T>` value where `T` is `Decodable`
 */
-public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> Decoded<T> {
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> Decoded<T> {
   return JSON(object) <| rootKey
 }
 
@@ -156,18 +156,18 @@ public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: St
   ```
   do {
     let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: Decoded<[String]> = decodeWithRootKey("value", object)
+    let str: Decoded<[String]> = decode(object, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter rootKey: The root key that contains the object to decode
   - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<[T]>` value where `T` is `Decodable`
 */
-public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> Decoded<[T]> {
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> Decoded<[T]> {
   return JSON(object) <|| rootKey
 }
 
@@ -187,19 +187,19 @@ public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: St
   ```
   do {
     let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: String? = decodeWithRootKey("value", object)
+    let str: String? = decode(object, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter rootKey: The root key that contains the object to decode
   - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<T>` value where `T` is `Decodable`
 */
-public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> T? {
-  return decodeWithRootKey(rootKey, object).value
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> T? {
+  return decode(object, rootKey: rootKey).value
 }
 
 /**
@@ -219,18 +219,18 @@ public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: St
   ```
   do {
     let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: [String]? = decodeWithRootKey("value", object)
+    let str: [String]? = decode(object, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter rootKey: The root key that contains the object to decode
   - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<[T]>` value where `T` is `Decodable`
 */
-public func decodeWithRootKey<T: Decodable where T == T.DecodedType>(rootKey: String, _ object: AnyObject) -> [T]? {
-  return decodeWithRootKey(rootKey, object).value
+public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> [T]? {
+  return decode(object, rootKey: rootKey).value
 }
 

--- a/Argo/Functions/decode.swift
+++ b/Argo/Functions/decode.swift
@@ -111,11 +111,10 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> 
 }
 
 /**
-  Attempt to transform `AnyObject` into a `Decodable` value using a specified root key.
+  Attempt to transform `AnyObject` into a `Decodable` value using a specified
+  root key.
 
-  This function expects the object to be a dictionary of the type `[String: JSON]`.
-
-  This function attpemts to extract the embedded JSON object from the
+  This function attempts to extract the embedded `JSON` object from the
   dictionary at the specified key and transform it into a `Decodable` value.
   This works based on the type you ask for.
 
@@ -124,29 +123,28 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject) -> 
 
   ```
   do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: Decoded<String> = decode(object, rootKey: "value")
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: AnyObject] ?? [:]
+    let str: Decoded<String> = decode(dict, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter dict: The dictionary containing the `AnyObject` instance to
+                    attempt to decode
   - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<T>` value where `T` is `Decodable`
 */
-public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> Decoded<T> {
-  return JSON(object) <| rootKey
+public func decode<T: Decodable where T == T.DecodedType>(dict: [String: AnyObject], rootKey: String) -> Decoded<T> {
+  return JSON(dict) <| rootKey
 }
 
 /**
   Attempt to transform `AnyObject` into an `Array` of `Decodable` value using a
   specified root key.
 
-  This function expects the object to be a dictionary of the type `[String: JSON]`.
-
-  This function attpemts to extract the embedded JSON object from the
+  This function attempts to extract the embedded `JSON` object from the
   dictionary at the specified key and transform it into an `Array` of
   `Decodable` values. This works based on the type you ask for.
 
@@ -155,29 +153,28 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, roo
 
   ```
   do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: Decoded<[String]> = decode(object, rootKey: "value")
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: AnyObject] ?? [:]
+    let str: Decoded<[String]> = decode(dict, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter dict: The dictionary containing the `AnyObject` instance to
+                    attempt to decode
   - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<[T]>` value where `T` is `Decodable`
 */
-public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> Decoded<[T]> {
-  return JSON(object) <|| rootKey
+public func decode<T: Decodable where T == T.DecodedType>(dict: [String: AnyObject], rootKey: String) -> Decoded<[T]> {
+  return JSON(dict) <|| rootKey
 }
 
 /**
   Attempt to transform `AnyObject` into a `Decodable` value using a specified
   root key and return an `Optional`.
 
-  This function expects the object to be a dictionary of the type `[String: JSON]`.
-
-  This function attpemts to extract the embedded JSON object from the
+  This function attempts to extract the embedded `JSON` object from the
   dictionary at the specified key and transform it into a `Decodable` value,
   returning an `Optional`. This works based on the type you ask for.
 
@@ -186,31 +183,30 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, roo
 
   ```
   do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: String? = decode(object, rootKey: "value")
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: AnyObject] ?? [:]
+    let str: String? = decode(dict, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter dict: The dictionary containing the `AnyObject` instance to
+                    attempt to decode
   - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<T>` value where `T` is `Decodable`
 */
-public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> T? {
-  return decode(object, rootKey: rootKey).value
+public func decode<T: Decodable where T == T.DecodedType>(dict: [String: AnyObject], rootKey: String) -> T? {
+  return decode(dict, rootKey: rootKey).value
 }
 
 /**
   Attempt to transform `AnyObject` into an `Array` of `Decodable` value using a
   specified root key and return an `Optional`
 
-  This function expects the object to be a dictionary of the type `[String: JSON]`.
-
-  This function attpemts to extract the embedded JSON object from the
+  This function attempts to extract the embedded `JSON` object from the
   dictionary at the specified key and transform it into an `Array` of
-  `Decodable` values, returninh an `Optional`. This works based on the type you
+  `Decodable` values, returning an `Optional`. This works based on the type you
   ask for.
 
   For example, the following code attempts to decode to `Optional<[String]>`,
@@ -218,19 +214,19 @@ public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, roo
 
   ```
   do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: [String]? = decode(object, rootKey: "value")
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: AnyObject] ?? [:]
+    let str: [String]? = decode(dict, rootKey: "value")
   } catch {
     // handle error
   }
   ```
 
-  - parameter object: The `AnyObject` instance to attempt to decode
+  - parameter dict: The dictionary containing the `AnyObject` instance to
+                    attempt to decode
   - parameter rootKey: The root key that contains the object to decode
 
   - returns: A `Decoded<[T]>` value where `T` is `Decodable`
 */
-public func decode<T: Decodable where T == T.DecodedType>(object: AnyObject, rootKey: String) -> [T]? {
-  return decode(object, rootKey: rootKey).value
+public func decode<T: Decodable where T == T.DecodedType>(dict: [String: AnyObject], rootKey: String) -> [T]? {
+  return decode(dict, rootKey: rootKey).value
 }
-

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -11,7 +11,7 @@ class ExampleTests: XCTestCase {
   }
 
   func testJSONWithRootObject() {
-    let user: User? = JSONFromFile("root_object").flatMap(curry(decodeWithRootKey)("user"))
+    let user: User? = JSONFromFile("root_object").flatMap { decode($0, rootKey: "user") }
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -21,7 +21,7 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingNonFinalClass() {
-    let url: NSURL? = JSONFromFile("url").flatMap(curry(decodeWithRootKey)("url"))
+    let url: NSURL? = JSONFromFile("url").flatMap { decode($0, rootKey: "url") }
 
     XCTAssert(url != nil)
     XCTAssert(url?.absoluteString == "http://example.com")

--- a/ArgoTests/Tests/ExampleTests.swift
+++ b/ArgoTests/Tests/ExampleTests.swift
@@ -11,7 +11,8 @@ class ExampleTests: XCTestCase {
   }
 
   func testJSONWithRootObject() {
-    let user: User? = JSONFromFile("root_object").flatMap { decode($0, rootKey: "user") }
+    let object = JSONFromFile("root_object") as? [String: AnyObject]
+    let user: User? = object.flatMap { decode($0, rootKey: "user") }
 
     XCTAssert(user != nil)
     XCTAssert(user?.id == 1)
@@ -21,7 +22,8 @@ class ExampleTests: XCTestCase {
   }
 
   func testDecodingNonFinalClass() {
-    let url: NSURL? = JSONFromFile("url").flatMap { decode($0, rootKey: "url") }
+    let object = JSONFromFile("url") as? [String: AnyObject]
+    let url: NSURL? = object.flatMap { decode($0, rootKey: "url") }
 
     XCTAssert(url != nil)
     XCTAssert(url?.absoluteString == "http://example.com")


### PR DESCRIPTION
I think the original reason for ordering the arguments as `rootKey`,
`object` was to be able to curry the function and partially apply the root
key (as seen in the tests). IMO, this is a weird optimization and let to a
kinda funky API. I think it probably makes more sense to accept that
currying in this way isn't reasonable, and instead order the arguments so
that our `decode` functions have a consistent pattern.

I've also re-ordered these functions for pedantic reasons.