### PR TITLE
Generalize the type for `sequence` taking a dict

### DIFF
--- a/Argo/Functions/sequence.swift
+++ b/Argo/Functions/sequence.swift
@@ -42,8 +42,8 @@ public func sequence<T>(xs: [Decoded<T>]) -> Decoded<[T]> {
   - returns: A `Decoded` `Dictionary` of unwrapped `T` values assigned to their
              original keys
 */
-public func sequence<T>(xs: [String: Decoded<T>]) -> Decoded<[String: T]> {
-  var accum = Dictionary<String, T>(minimumCapacity: xs.count)
+public func sequence<Key, Value>(xs: [Key: Decoded<Value>]) -> Decoded<[Key: Value]> {
+  var accum = Dictionary<Key, Value>(minimumCapacity: xs.count)
 
   for (key, x) in xs {
     switch x {


### PR DESCRIPTION
There wasn't actually any real reason to limit this to working on
`[String: Decoded<T>]` values. Instead, we should be able to use this
function with any key type.

Another change that came about because of having trouble writing documentation.
Fun stuff.