### PR TITLE
Add an issue template to speed up issue resolution

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+_[Description of the issue you are experiencing]_
+
+### Error Messages
+
+_List all the error messages or warnings you are seeing, if any._
+
+### Sample JSON
+
+```
+{
+  "key": "value"
+}
+```
+
+### Models
+
+_All models involved, including their `Decodable` implementations._
+
+```
+struct User {
+  // ...
+}
+
+extension User: Decodable {
+  // ...
+}
+```
+
+### Argo Version
+
+_example: Argo 3.0.0_
+
+### Dependency Manager
+
+_examples: Carthage, Cocoapods, git submodules, copied code, etc._


### PR DESCRIPTION
Github recently added the capability to add a file to use as an issue template.
I've used these before on other repos and they are very useful. We get a decent
amount of issue requests in Argo and sometimes they require us to ask for more
information.  This will hopefully help get all the information we need to
resolve most issues.