### PR TITLE
WIP: Improve speed with multithreading

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		EA6DD69D1AB383FB00CA3A5B /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6DD69B1AB383FB00CA3A5B /* PerformanceTests.swift */; };
 		EA6DD69F1AB384C700CA3A5B /* big_data.json in Resources */ = {isa = PBXBuildFile; fileRef = EA6DD69E1AB384C700CA3A5B /* big_data.json */; };
 		EA6DD6A01AB384C700CA3A5B /* big_data.json in Resources */ = {isa = PBXBuildFile; fileRef = EA6DD69E1AB384C700CA3A5B /* big_data.json */; };
+		EA70643A1D1DB16700BF9471 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA7064391D1DB16700BF9471 /* Task.swift */; };
 		EA9159F61BDE74BC00D85292 /* Argo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04D5A41BBF2047001DE23B /* Argo.swift */; };
 		EA9159F71BDE74C700D85292 /* catDecoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EF432E1BBC728A001886BA /* catDecoded.swift */; };
 		EA9159F81BDE74E400D85292 /* Monad.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA04D5901BBF1F40001DE23B /* Monad.swift */; };
@@ -299,6 +300,7 @@
 		EA4EAF7219DD96330036AE0D /* types_fail_embedded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = types_fail_embedded.json; sourceTree = "<group>"; };
 		EA6DD69B1AB383FB00CA3A5B /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		EA6DD69E1AB384C700CA3A5B /* big_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = big_data.json; sourceTree = "<group>"; };
+		EA7064391D1DB16700BF9471 /* Task.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		EABDF6891A9CD46100B6CC83 /* SwiftDictionaryDecodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftDictionaryDecodingTests.swift; sourceTree = "<group>"; };
 		EABDF68D1A9CD4EA00B6CC83 /* PListFileReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PListFileReader.swift; sourceTree = "<group>"; };
 		EABDF68E1A9CD4EA00B6CC83 /* types.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = types.plist; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 				F87EB6A01ABC5F1300E3B0AB /* Decodable.swift */,
 				F87EB6A11ABC5F1300E3B0AB /* StandardTypes.swift */,
 				F84318A71B9A2D7A00165216 /* DecodeError.swift */,
+				EA7064391D1DB16700BF9471 /* Task.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -1071,6 +1074,7 @@
 				F84318A81B9A2D7A00165216 /* DecodeError.swift in Sources */,
 				F876F1D71B56FBB300B38589 /* Runes.swift in Sources */,
 				F8CBE6671A64521000316FBC /* Dictionary.swift in Sources */,
+				EA70643A1D1DB16700BF9471 /* Task.swift in Sources */,
 				EAD9FAF619D0F7900031E006 /* Decode.swift in Sources */,
 				F87EB6B01ABC5F1300E3B0AB /* StandardTypes.swift in Sources */,
 				EA04D5911BBF1F40001DE23B /* Monad.swift in Sources */,

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -30,6 +30,7 @@ public extension JSON {
       if v.count > divider {
         let totalSlices = Int(ceil(Double(v.count) / Double(divider)))
         var final: [JSON] = []
+        final.reserveCapacity(v.count)
         (0..<totalSlices).forEach { _ in group.enter() }
         for i in 0..<totalSlices {
           let slice: [AnyObject] = [] + v[i*divider..<min(i*divider+divider, v.endIndex)]

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-let group = DispatchGroup()
-let queue = DispatchQueue.global(attributes: DispatchQueue.GlobalAttributes.qosUserInitiated)
-
 /// A type safe representation of JSON.
 public enum JSON {
   case Object([Swift.String: JSON])
@@ -26,20 +23,8 @@ public extension JSON {
     switch json {
 
     case let v as [AnyObject]:
-      let divider: Int = 200
-      if v.count > divider {
-        let totalSlices = Int(ceil(Double(v.count) / Double(divider)))
-        var final: [JSON] = []
-        final.reserveCapacity(v.count)
-        (0..<totalSlices).forEach { _ in group.enter() }
-        for i in 0..<totalSlices {
-          let slice: [AnyObject] = [] + v[i*divider..<min(i*divider+divider, v.endIndex)]
-          queue.async {
-            final += slice.map(JSON.init)
-            group.leave()
-          }
-        }
-        group.wait()
+      if v.count > 100 {
+        let final = divideAndConquer(input: v, transform: JSON.init)
         self = .Array(final)
       } else {
         self = .Array(v.map(JSON.init))

--- a/Argo/Types/JSON.swift
+++ b/Argo/Types/JSON.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+let group = DispatchGroup()
+let queue = DispatchQueue.global(attributes: DispatchQueue.GlobalAttributes.qosUserInitiated)
+
 /// A type safe representation of JSON.
 public enum JSON {
   case Object([Swift.String: JSON])
@@ -23,7 +26,23 @@ public extension JSON {
     switch json {
 
     case let v as [AnyObject]:
-      self = .Array(v.map(JSON.init))
+      let divider: Int = 200
+      if v.count > divider {
+        let totalSlices = Int(ceil(Double(v.count) / Double(divider)))
+        var final: [JSON] = []
+        (0..<totalSlices).forEach { _ in group.enter() }
+        for i in 0..<totalSlices {
+          let slice: [AnyObject] = [] + v[i*divider..<min(i*divider+divider, v.endIndex)]
+          queue.async {
+            final += slice.map(JSON.init)
+            group.leave()
+          }
+        }
+        group.wait()
+        self = .Array(final)
+      } else {
+        self = .Array(v.map(JSON.init))
+      }
 
     case let v as [Swift.String: AnyObject]:
       self = .Object(v.map(JSON.init))

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -158,6 +158,7 @@ public extension Collection where Iterator.Element: Decodable, Iterator.Element 
       if a.count > divider {
         let totalSlices = Int(ceil(Double(a.count) / Double(divider)))
         var final: [Decoded<Generator.Element>] = []
+        final.reserveCapacity(a.count)
         (0..<totalSlices).forEach { _ in group.enter() }
         for i in 0..<totalSlices {
           let d = i*divider+divider

--- a/Argo/Types/StandardTypes.swift
+++ b/Argo/Types/StandardTypes.swift
@@ -154,22 +154,8 @@ public extension Collection where Iterator.Element: Decodable, Iterator.Element 
   static func decode(_ json: JSON) -> Decoded<[Generator.Element]> {
     switch json {
     case let .Array(a):
-      let divider: Int = 100
-      if a.count > divider {
-        let totalSlices = Int(ceil(Double(a.count) / Double(divider)))
-        var final: [Decoded<Generator.Element>] = []
-        final.reserveCapacity(a.count)
-        (0..<totalSlices).forEach { _ in group.enter() }
-        for i in 0..<totalSlices {
-          let d = i*divider+divider
-          let min = d < a.endIndex ? d : a.endIndex
-          let slice: [JSON] = [] + a[i*divider..<min]
-          queue.async {
-            final += slice.map(Generator.Element.decode)
-            group.leave()
-          }
-        }
-        group.wait()
+      if a.count > 100 {
+        let final = divideAndConquer(input: a, transform: Generator.Element.decode)
         return sequence(final)
       } else {
         return sequence(a.map(Generator.Element.decode))

--- a/Argo/Types/Task.swift
+++ b/Argo/Types/Task.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+private let queue = OperationQueue()
+
+final class Task<U, T> {
+  var array: ArraySlice<U>
+  var result: [T]
+  let transform: (U) -> T
+
+  init(_ array: ArraySlice<U>, _ transform: (U) -> T) {
+    self.array = array
+    result = []
+    result.reserveCapacity(array.count)
+    self.transform = transform
+  }
+
+  func perform() {
+    result = array.map(transform)
+  }
+}
+
+private let divider = 100
+
+func divideAndConquer<U, T>(input: [U], transform: (U) -> T) -> [T] {
+  let count = Int(ceil(Double(input.count) / Double(divider)))
+
+  var final: [T] = []
+  final.reserveCapacity(input.count)
+
+  var tasks: [Task<U, T>] = []
+  tasks.reserveCapacity(divider)
+
+  for i in 0..<divider {
+    let startIndex = i*count
+    let endIndex = min(i*count+count, input.endIndex) - 1
+    let slice = input[startIndex...endIndex]
+
+    let task = Task<U, T>(slice, transform)
+    tasks.append(task)
+  }
+
+  queue.maxConcurrentOperationCount = divider
+
+  tasks.forEach { task in
+    queue.addOperation(task.perform)
+  }
+  queue.waitUntilAllOperationsAreFinished()
+
+  for t in tasks {
+    final += t.result
+  }
+
+  return final
+}

--- a/ArgoTests/Tests/PerformanceTests.swift
+++ b/ArgoTests/Tests/PerformanceTests.swift
@@ -19,6 +19,14 @@ class PerformanceTests: XCTestCase {
     }
   }
 
+  func testOverAllPerformance() {
+    let json: AnyObject = JSONFromFile(file: "big_data")!
+
+    measure {
+      _ = [TestModel].decode(JSON(json))
+    }
+  }
+
   func testBigDataDecodesCorrectly() {
     let json: AnyObject = JSONFromFile(file: "big_data")!
     let j = JSON(json)


### PR DESCRIPTION
By using an `OperationQueue` and pre-allocating memory in our arrays we are able to significantly increase the speed of JSON parsing and decoding.

Currently on master, parsing averages 0.973s and decoding averages 0.79s with a combined average of 1.763s. With the changes on this branch we were able to achieve a parsing average of 0.393s and a decoding average of 0.294s with a combined average of 0.687s. This is a 61% increase in speed.

I haven't noticed a significant difference between 10 or 100 threads (by setting `divider`) but 100 did seem faster. I'm checking if an array is over 100 before deciding to use threading but that means that if there are 101 items, we'll try to use 100 threads to decode them which probably isn't the most efficient.
I think there is still some work to be done around when to use threading, how many threads to use, and how many items should be processed in each thread. However, this is pretty cool how it is now.
