### PR TITLE
Add project specific vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,4 @@
+set tabstop=2
+set shiftwidth=2
+
+let g:xcode_default_scheme = 'Argo-Mac'


### PR DESCRIPTION
This vimrc defines our local tab preference, as well as specifies a default
scheme to be used by [xcode.vim](https://github.com/gfontenot/vim-xcode).

You can tell vim to read this local vimrc by default by ensuring that you have
the following in your main vimrc:

```
set secure  " Don't let external configs do scary shit
set exrc    " Load local vimrc if found
```