### PR TITLE
Use Semigroup type to coalesce multiple errors

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -546,8 +546,8 @@
 				EA395DC31A52F8EB00EB607E /* array_root.json */,
 				EA395DC91A52FC1400EB607E /* root_object.json */,
 				EA6DD69E1AB384C700CA3A5B /* big_data.json */,
-				EA47BB551AFC5DAC002D2CCD /* user_with_bad_type.json */,
 				EA47BB581AFC5E65002D2CCD /* user_without_key.json */,
+				EA47BB551AFC5DAC002D2CCD /* user_with_bad_type.json */,
 			);
 			path = JSON;
 			sourceTree = "<group>";

--- a/Argo/Types/Decoded/Applicative.swift
+++ b/Argo/Types/Decoded/Applicative.swift
@@ -47,9 +47,10 @@ public extension Decoded {
     - returns: A value of type `Decoded<U>`
   */
   func apply<U>(_ f: Decoded<(T) -> U>) -> Decoded<U> {
-    switch f {
-    case let .success(function): return self.map(function)
-    case let .failure(error): return .failure(error)
+    switch (f, self) {
+    case let (.success(function), _): return self.map(function)
+    case let (.failure(le), .failure(re)): return .failure(le + re)
+    case let (.failure(f), _): return .failure(f)
     }
   }
 }

--- a/Argo/Types/Decoded/Decoded.swift
+++ b/Argo/Types/Decoded/Decoded.swift
@@ -53,6 +53,7 @@ public extension Decoded {
     case let .failure(.typeMismatch(expected, actual)):
       return .failure(.typeMismatch(expected: expected, actual: actual))
     case let .failure(.custom(x)): return .failure(.custom(x))
+    case let .failure(.multiple(es)): return .failure(.multiple(es))
     }
   }
 
@@ -108,6 +109,18 @@ public extension Decoded {
   */
   static func customError<T>(_ message: String) -> Decoded<T> {
     return .failure(.custom(message))
+  }
+
+  /**
+   Convenience function for creating `.Multiple` errors
+
+   - parameter errors: The errors
+
+   - returns: A `Decoded.Failure` with a `.Multiple` error constructed from the
+   provided `errors` value
+   */
+  static func multipleErrors<T>(errors: [DecodeError]) -> Decoded<T> {
+    return .failure(.multiple(errors))
   }
 }
 

--- a/ArgoTests/Tests/DecodedTests.swift
+++ b/ArgoTests/Tests/DecodedTests.swift
@@ -55,7 +55,44 @@ class DecodedTests: XCTestCase {
     default: XCTFail("Unexpected Case Occurred")
     }
   }
-  
+
+  func testDecodedMultipleErrors() {
+    let user: Decoded<User> = decode([
+      "id": "1"
+    ])
+
+    let expected: [DecodeError] = [
+      .typeMismatch(expected: "Int", actual: "String(1)"),
+      .missingKey("name")
+    ]
+
+    switch user {
+    case let .failure(.multiple(errors)): XCTAssert(errors == expected)
+    default: XCTFail("Unexpected Case Occurred")
+    }
+  }
+
+  func testDecodedMultipleErrorsWithOptionalKeyTypeMismatch() {
+    let user: Decoded<User> = decode([
+      "id": 1,
+      "email": 1
+    ])
+
+    let expected: [DecodeError] = [
+      .missingKey("name"),
+      .typeMismatch(expected: "String", actual: String(describing: JSON.number(1)))
+    ]
+
+    switch user {
+    case let .failure(.multiple(errors)):
+      print("expected: \(expected)")
+      print("actual: \(errors)")
+
+      XCTAssert(errors == expected)
+    default: XCTFail("Unexpected Case Occurred")
+    }
+  }
+
   func testDecodedMaterializeSuccess() {
     let user: Decoded<User> = decode(json(fromFile: "user_with_email")!)
     let materialized = materialize { user.value! }


### PR DESCRIPTION
Inspired by this Haskell [Validation type]. Which is essentially the same as `Either` but with an accumulating left hand side. This applied to `Decoded` is a `Decoded` with an accumulating `DecodedError`.

This allows consumers to be warned about all the JSON errors, instead of having to fix each one by one.

[Validation type]: https://github.com/tonymorris/validation