### PR TITLE
Remove remaining NSNumber coercions

### DIFF
--- a/Sources/Argo/Extensions/RawRepresentable.swift
+++ b/Sources/Argo/Extensions/RawRepresentable.swift
@@ -5,8 +5,11 @@
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == String {
   static func decode(_ json: JSON) -> Decoded<Self> {
     switch json {
-    case let .string(s): return self.init(rawValue: s).map(pure) ?? .typeMismatch(expected: "rawValue for \(self)", actual: json)
-    default: return .typeMismatch(expected: "String", actual: json)
+    case let .string(s):
+      return self.init(rawValue: s)
+        .map(pure) ?? .typeMismatch(expected: "rawValue for \(self)", actual: json)
+    default:
+      return .typeMismatch(expected: "String", actual: json)
     }
   }
 }
@@ -18,8 +21,11 @@ public extension Decodable where Self.DecodedType == Self, Self: RawRepresentabl
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == Int {
   static func decode(_ json: JSON) -> Decoded<Self> {
     switch json {
-    case let .number(n): return self.init(rawValue: n as Int).map(pure) ?? .typeMismatch(expected: "rawValue for \(self)", actual: json)
-    default: return .typeMismatch(expected: "Int", actual: json)
+    case let .number(n):
+      return self.init(rawValue: n.intValue)
+        .map(pure) ?? .typeMismatch(expected: "rawValue for \(self)", actual: json)
+    default:
+      return .typeMismatch(expected: "Int", actual: json)
     }
   }
 }

--- a/Sources/Argo/Types/JSON.swift
+++ b/Sources/Argo/Types/JSON.swift
@@ -33,7 +33,7 @@ public extension JSON {
 
     case let v as NSNumber:
       if v.isBool {
-        self = .bool(v as Bool)
+        self = .bool(v.boolValue)
       } else {
         self = .number(v)
       }


### PR DESCRIPTION
There were two other places that we were using `as` coercion to move
from NSNumber to our expected types. These actually don't compile at all
on Linux, which is interesting, so it's probably best if we just remove
these.

Also taking this opportunity to clean up the style on our
RawRepresentable implementations as well.