### PR TITLE
Improve the way we detect Boolean values

### DIFF
--- a/Sources/Argo/Extensions/NSNumber.swift
+++ b/Sources/Argo/Extensions/NSNumber.swift
@@ -2,6 +2,6 @@ import Foundation
 
 extension NSNumber {
   var isBool: Bool {
-    return CFBooleanGetTypeID() == CFGetTypeID(self)
+    return type(of: self) == type(of: NSNumber(value: true))
   }
 }

--- a/Tests/ArgoTests/Tests/TypeTests.swift
+++ b/Tests/ArgoTests/Tests/TypeTests.swift
@@ -41,4 +41,10 @@ class TypeTests: XCTestCase {
     XCTAssert(bools?.bool == true)
     XCTAssert(bools?.number == true)
   }
+
+  func testBooleanIdentification() {
+    let j = json(fromFile: "booleans").map(JSON.init)!
+    let boolean: JSON? = (j <| "realBool").value
+    XCTAssert(boolean == .bool(true))
+  }
 }


### PR DESCRIPTION
Previously, we were relying on functionality found in CoreFoundation in
order to determine if an NSNumber instance was representing an
underlying Boolean value. This worked well, but unfortunately
CoreFoundation isn't available on Linux, which means that Argo would
never be able to compile. We'd like Argo to be as widely availably as
possible, so we need to find another solution.

Luckily, it looks like we can use `type(of:)` to determine this. That
function ships with Swift itself and so _should_ mean that we're now
able to compile on Linux without any behavioral change.

I added another test to ensure that our decoding is operating as we'd
expect. The previous test seemed like it was vulnerable to false
positives.