### PR TITLE
Add `import CoreFoundation` for `CFBooleanGetTypeID` and `CFGetTypeID`

### DIFF
--- a/Sources/Argo/Extensions/NSNumber.swift
+++ b/Sources/Argo/Extensions/NSNumber.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreFoundation
 
 extension NSNumber {
   var isBool: Bool {


### PR DESCRIPTION
This supersedes #428. See https://github.com/thoughtbot/Argo/pull/428#issuecomment-258727596.

I confirmed this makes the library buildable on Linux.