### PR TITLE
Replace 'Generator' with 'Iterator'

### DIFF
--- a/Sources/Argo/Types/StandardTypes.swift
+++ b/Sources/Argo/Types/StandardTypes.swift
@@ -194,9 +194,9 @@ public extension Collection where Iterator.Element: Decodable, Iterator.Element 
 
     - returns: A decoded array of values
   */
-  static func decode(_ json: JSON) -> Decoded<[Generator.Element]> {
+  static func decode(_ json: JSON) -> Decoded<[Iterator.Element]> {
     switch json {
-    case let .array(a): return sequence(a.map(Generator.Element.decode))
+    case let .array(a): return sequence(a.map(Iterator.Element.decode))
     default: return .typeMismatch(expected: "Array", actual: json)
     }
   }


### PR DESCRIPTION
In the latest Swift 3.1 snapshots Argo ceases to build.

```
/.../Sources/Argo/Types/StandardTypes.swift:197:48: error: 'Generator' has been renamed to 'Iterator'
  static func decode(_ json: JSON) -> Decoded<[Generator.Element]> {
                                               ^~~~~~~~~
                                               Iterator
Swift.Collection:3:22: note: 'Generator' has been explicitly marked unavailable here
    public typealias Generator = Self.Iterator
                     ^
...
<unknown>:0: error: build had 1 command failures
```

I _know_ it fixes the build problems on the latest snapshots. Though I _think_ this is safe for all of Swift 3.x. I assume the CI will catch it if I am wrong.