### PR TITLE
An attempt at "Lazy" JSON parsing

### DIFF
--- a/Argo.xcodeproj/project.pbxproj
+++ b/Argo.xcodeproj/project.pbxproj
@@ -93,6 +93,9 @@
 		EA1200CC1BAB5CBA006DDBD8 /* RawRepresentableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1200CA1BAB5CBA006DDBD8 /* RawRepresentableTests.swift */; };
 		EA1200CD1BAB621C006DDBD8 /* RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF92789C1B9365900038A7E1 /* RawRepresentable.swift */; };
 		EA1200CE1BAB621C006DDBD8 /* RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF92789C1B9365900038A7E1 /* RawRepresentable.swift */; };
+		EA2F74A41EC6064C00AEC72D /* PartialTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2F74A31EC6064C00AEC72D /* PartialTestModel.swift */; };
+		EA2F74A51EC6064C00AEC72D /* PartialTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2F74A31EC6064C00AEC72D /* PartialTestModel.swift */; };
+		EA2F74A61EC6064C00AEC72D /* PartialTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2F74A31EC6064C00AEC72D /* PartialTestModel.swift */; };
 		EA395DC21A5209C000EB607E /* post_bad_comments.json in Resources */ = {isa = PBXBuildFile; fileRef = F8E33FA41A51E0C20025A6E5 /* post_bad_comments.json */; };
 		EA395DC41A52F8EB00EB607E /* array_root.json in Resources */ = {isa = PBXBuildFile; fileRef = EA395DC31A52F8EB00EB607E /* array_root.json */; };
 		EA395DC51A52F8EE00EB607E /* array_root.json in Resources */ = {isa = PBXBuildFile; fileRef = EA395DC31A52F8EB00EB607E /* array_root.json */; };
@@ -298,6 +301,7 @@
 		EA08313219D5EEF2003B90D7 /* post_comments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = post_comments.json; sourceTree = "<group>"; };
 		EA08313419D5EFC0003B90D7 /* types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = types.json; sourceTree = "<group>"; };
 		EA1200CA1BAB5CBA006DDBD8 /* RawRepresentableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawRepresentableTests.swift; sourceTree = "<group>"; };
+		EA2F74A31EC6064C00AEC72D /* PartialTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartialTestModel.swift; sourceTree = "<group>"; };
 		EA395DC31A52F8EB00EB607E /* array_root.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = array_root.json; sourceTree = "<group>"; };
 		EA395DC61A52F93B00EB607E /* ExampleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		EA395DC91A52FC1400EB607E /* root_object.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = root_object.json; sourceTree = "<group>"; };
@@ -524,6 +528,7 @@
 				EAD9FB0119D211C10031E006 /* Post.swift */,
 				EAD9FB1719D49A3E0031E006 /* TestModel.swift */,
 				F802D4C21A5EE061005E236C /* URL.swift */,
+				EA2F74A31EC6064C00AEC72D /* PartialTestModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1014,6 +1019,7 @@
 				809754F01BADF3E400C409E6 /* DecodedTests.swift in Sources */,
 				809754F11BADF3E400C409E6 /* RawRepresentableTests.swift in Sources */,
 				809754F31BADF3E400C409E6 /* PListFileReader.swift in Sources */,
+				EA2F74A61EC6064C00AEC72D /* PartialTestModel.swift in Sources */,
 				809754EB1BADF3E400C409E6 /* EmbeddedJSONDecodingTests.swift in Sources */,
 				F8C592841CB726FF007C5ABC /* Booleans.swift in Sources */,
 				809754EA1BADF3E400C409E6 /* OptionalPropertyDecodingTests.swift in Sources */,
@@ -1092,6 +1098,7 @@
 				EAD9FB1219D30E660031E006 /* EmbeddedJSONDecodingTests.swift in Sources */,
 				F802D4C31A5EE061005E236C /* URL.swift in Sources */,
 				EABDF68F1A9CD4EA00B6CC83 /* PListFileReader.swift in Sources */,
+				EA2F74A41EC6064C00AEC72D /* PartialTestModel.swift in Sources */,
 				EAD9FB1019D21AF50031E006 /* JSONFileReader.swift in Sources */,
 				F8C592821CB726FB007C5ABC /* Booleans.swift in Sources */,
 				EAD9FB0219D211C10031E006 /* Post.swift in Sources */,
@@ -1144,6 +1151,7 @@
 				F8EF75731A4CEC7800BDCC2D /* Comment.swift in Sources */,
 				F802D4C41A5EE172005E236C /* URL.swift in Sources */,
 				EABDF6901A9CD4EA00B6CC83 /* PListFileReader.swift in Sources */,
+				EA2F74A51EC6064C00AEC72D /* PartialTestModel.swift in Sources */,
 				F8EF75721A4CEC7800BDCC2D /* User.swift in Sources */,
 				F8C592831CB726FE007C5ABC /* Booleans.swift in Sources */,
 				F8EF756B1A4CEC6400BDCC2D /* EmbeddedJSONDecodingTests.swift in Sources */,

--- a/Sources/Argo/Types/JSON.swift
+++ b/Sources/Argo/Types/JSON.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// A type safe representation of JSON.
 public enum JSON {
-  case object([String: JSON])
-  case array([JSON])
+  case object([String: Any])
+  case array([Any])
   case string(String)
   case number(NSNumber)
   case bool(Bool)
@@ -22,11 +22,14 @@ public extension JSON {
   init(_ json: Any) {
     switch json {
 
+    case let v as JSON:
+      self = v
+
     case let v as [Any]:
-      self = .array(v.map(JSON.init))
+      self = .array(v)
 
     case let v as [String: Any]:
-      self = .object(v.map(JSON.init))
+      self = .object(v)
 
     case let v as String:
       self = .string(v)
@@ -81,8 +84,8 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
   case let (.string(l), .string(r)): return l == r
   case let (.number(l), .number(r)): return l == r
   case let (.bool(l), .bool(r)): return l == r
-  case let (.array(l), .array(r)): return l == r
-  case let (.object(l), .object(r)): return l == r
+  case let (.array(l), .array(r)): return l.map(JSON.init) == r.map(JSON.init)
+  case let (.object(l), .object(r)): return l.map(JSON.init) == r.map(JSON.init)
   case (.null, .null): return true
   default: return false
   }

--- a/Sources/Argo/Types/StandardTypes.swift
+++ b/Sources/Argo/Types/StandardTypes.swift
@@ -196,7 +196,7 @@ public extension Collection where Iterator.Element: Decodable, Iterator.Element 
   */
   static func decode(_ json: JSON) -> Decoded<[Iterator.Element]> {
     switch json {
-    case let .array(a): return sequence(a.map(Iterator.Element.decode))
+    case let .array(a): return sequence(a.map({ Iterator.Element.decode(JSON($0)) }))
     default: return .typeMismatch(expected: "Array", actual: json)
     }
   }
@@ -246,7 +246,7 @@ public extension ExpressibleByDictionaryLiteral where Value: Decodable, Value ==
   */
   static func decode(_ json: JSON) -> Decoded<[String: Value]> {
     switch json {
-    case let .object(o): return sequence(Value.decode <^> o)
+    case let .object(o): return sequence({ Value.decode(JSON($0)) } <^> o)
     default: return .typeMismatch(expected: "Object", actual: json)
     }
   }
@@ -296,7 +296,7 @@ public func decodeObject<T: Decodable>(_ json: JSON) -> Decoded<[String: T]> whe
 */
 public func decodedJSON(_ json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
-  case let .object(o): return guardNull(key, o[key] ?? .null)
+  case let .object(o): return guardNull(key, o[key].map(JSON.init) ?? .null)
   default: return .typeMismatch(expected: "Object", actual: json)
   }
 }

--- a/Tests/ArgoTests/Models/PartialTestModel.swift
+++ b/Tests/ArgoTests/Models/PartialTestModel.swift
@@ -1,0 +1,19 @@
+import Argo
+import Runes
+import Curry
+
+struct PartialTestModel {
+  let string: String
+  let bool: Bool
+  let stringArray: [String]
+}
+
+extension PartialTestModel: Decodable {
+  static func decode(_ json: JSON) -> Decoded<PartialTestModel> {
+    let curriedInit = curry(self.init)
+    return curriedInit
+      <^> json <| ["user_opt", "name"]
+      <*> json <| "bool"
+      <*> json <|| "string_array"
+  }
+}

--- a/Tests/ArgoTests/Tests/PerformanceTests.swift
+++ b/Tests/ArgoTests/Tests/PerformanceTests.swift
@@ -19,6 +19,15 @@ class PerformanceTests: XCTestCase {
     }
   }
 
+  func testPartialDecodePerformance() {
+    let obj: Any = json(fromFile: "big_data")!
+    let j = JSON(obj)
+
+    measure {
+      _ = [PartialTestModel].decode(j)
+    }
+  }
+
   func testBigDataDecodesCorrectly() {
     let obj: Any = json(fromFile: "big_data")!
     let j = JSON(obj)


### PR DESCRIPTION
This is an attempt at lazy parsing JSON in hopes of better performance. Below is the entire test output (just the performance tests) but I'll summarize here. The theory is that the lazy parsing shouldn't add any time when decoding the full JSON but can cut down on time when only decoding part of the JSON. I've created another mode `PartialTestModel` that decodes from the same `JSON` as the `TestModel` but only decodes a few properties.

Currently on master, parsing averages to 1.136s and decoding the full model averages 0.733 totaling to **1.869s**. The partial model decodes in 0.117s totaling **1.253s**.

This branch, parsing averages to 0.009s and decoding the full model averages 2.014s totaling to **2.023s**. The partial model decodes in 0.552s totaling **0.561s**.

So you can see that this attempt at lazy JSON adds **8.2%** to the time for full decoding but saves **55%** when decoding the partial model. So worst case is a bit worse but best case could be much better. Seems like this is a positive thing but I want to hear other opinions.

-------------------------------------------------------------------------------------------

This branch:
```
Test Suite 'PerformanceTests' started at 2017-05-12 11:36:35.775
Test Case '-[ArgoTests.PerformanceTests testBigDataDecodesCorrectly]' started.
Test Case '-[ArgoTests.PerformanceTests testBigDataDecodesCorrectly]' passed (2.161 seconds).
Test Case '-[ArgoTests.PerformanceTests testDecodePerformance]' started.
Test Case '-[ArgoTests.PerformanceTests testDecodePerformance]' measured [Time, seconds] average: 2.014, relative standard deviation: 1.569%, values: [2.004167, 2.032448, 2.023439, 2.001006, 1.970307, 2.001316, 2.007409, 2.020993, 2.093751, 1.986349], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[ArgoTests.PerformanceTests testDecodePerformance]' passed (20.509 seconds).
Test Case '-[ArgoTests.PerformanceTests testParsePerformance]' started.
Test Case '-[ArgoTests.PerformanceTests testParsePerformance]' measured [Time, seconds] average: 0.009, relative standard deviation: 10.247%, values: [0.010456, 0.007621, 0.009246, 0.009345, 0.008630, 0.007998, 0.007957, 0.008947, 0.009619, 0.007634], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[ArgoTests.PerformanceTests testParsePerformance]' passed (0.441 seconds).
Test Case '-[ArgoTests.PerformanceTests testPartialDecodePerformance]' started.
Test Case '-[ArgoTests.PerformanceTests testPartialDecodePerformance]' measured [Time, seconds] average: 0.552, relative standard deviation: 3.189%, values: [0.561163, 0.541514, 0.546523, 0.537692, 0.537148, 0.598750, 0.551715, 0.536631, 0.557324, 0.553036], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[ArgoTests.PerformanceTests testPartialDecodePerformance]' passed (5.888 seconds).
Test Suite 'PerformanceTests' passed at 2017-05-12 11:37:04.777.
	 Executed 4 tests, with 0 failures (0 unexpected) in 29.000 (29.002) seconds
```
master:
```
Test Suite 'PerformanceTests' started at 2017-05-12 11:41:59.004
Test Case '-[ArgoTests.PerformanceTests testBigDataDecodesCorrectly]' started.
Test Case '-[ArgoTests.PerformanceTests testBigDataDecodesCorrectly]' passed (2.019 seconds).
Test Case '-[ArgoTests.PerformanceTests testDecodePerformance]' started.
Test Case '-[ArgoTests.PerformanceTests testDecodePerformance]' measured [Time, seconds] average: 0.733, relative standard deviation: 2.405%, values: [0.737361, 0.748237, 0.740130, 0.731497, 0.715472, 0.766685, 0.745634, 0.719830, 0.717083, 0.705184], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[ArgoTests.PerformanceTests testDecodePerformance]' passed (8.834 seconds).
Test Case '-[ArgoTests.PerformanceTests testParsePerformance]' started.
Test Case '-[ArgoTests.PerformanceTests testParsePerformance]' measured [Time, seconds] average: 1.136, relative standard deviation: 1.279%, values: [1.148678, 1.131917, 1.126283, 1.124288, 1.130257, 1.150127, 1.124245, 1.135282, 1.167864, 1.118230], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[ArgoTests.PerformanceTests testParsePerformance]' passed (11.719 seconds).
Test Case '-[ArgoTests.PerformanceTests testPartialDecodePerformance]' started.
Test Case '-[ArgoTests.PerformanceTests testPartialDecodePerformance]' measured [Time, seconds] average: 0.117, relative standard deviation: 3.129%, values: [0.115177, 0.119668, 0.114696, 0.122064, 0.116096, 0.118893, 0.112882, 0.115287, 0.121189, 0.109818], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[ArgoTests.PerformanceTests testPartialDecodePerformance]' passed (2.673 seconds).
Test Suite 'PerformanceTests' passed at 2017-05-12 11:42:24.251.
	 Executed 4 tests, with 0 failures (0 unexpected) in 25.245 (25.247) seconds
```