### PR TITLE
fix typos using misspell

### DIFF
--- a/Tests/ArgoTests/Tests/DecodedTests.swift
+++ b/Tests/ArgoTests/Tests/DecodedTests.swift
@@ -189,7 +189,7 @@ class DecodedTests: XCTestCase {
 
     switch (op(success), op(typeError), op(missingError), op(customError), op(multipleError)) {
     case (.success, .success, .success, .success, .success): XCTAssert(true)
-    default: XCTFail("Unexpected Case Occured")
+    default: XCTFail("Unexpected Case Occurred")
     }
   }
 }


### PR DESCRIPTION
This PR is part of a campaign to fix a lot of typos on github using https://github.com/client9/misspell!
You can see the progress on https://github.com/fixTypos/fix_typos/
