### PR TITLE
Fix tests for Swift 4

### DIFF
--- a/Tests/ArgoTests/Models/Booleans.swift
+++ b/Tests/ArgoTests/Models/Booleans.swift
@@ -2,7 +2,7 @@ import Argo
 import Curry
 import Runes
 
-struct Booleans: Decodable {
+struct Booleans: Argo.Decodable {
   let bool: Bool
   let number: Bool
 

--- a/Tests/ArgoTests/Models/Comment.swift
+++ b/Tests/ArgoTests/Models/Comment.swift
@@ -8,7 +8,7 @@ struct Comment {
   let authorName: String
 }
 
-extension Comment: Decodable {
+extension Comment: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<Comment> {
     return curry(self.init)
       <^> json <| "id"

--- a/Tests/ArgoTests/Models/Post.swift
+++ b/Tests/ArgoTests/Models/Post.swift
@@ -9,7 +9,7 @@ struct Post {
   let comments: [Comment]
 }
 
-extension Post: Decodable {
+extension Post: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<Post> {
     return curry(self.init)
       <^> json <| "id"
@@ -27,7 +27,7 @@ struct LocationPost {
   let location: Location?
 }
 
-extension LocationPost: Decodable {
+extension LocationPost: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<LocationPost> {
     return curry(self.init)
       <^> json <| "id"
@@ -44,7 +44,7 @@ struct Location {
   let title: String
 }
 
-extension Location: Decodable {
+extension Location: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<Location> {
     return curry(self.init)
       <^> json <| "lat"

--- a/Tests/ArgoTests/Models/TestModel.swift
+++ b/Tests/ArgoTests/Models/TestModel.swift
@@ -14,7 +14,7 @@ struct TestModel {
   let dict: [String: String]
 }
 
-extension TestModel: Decodable {
+extension TestModel: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<TestModel> {
     let curriedInit = curry(self.init)
     return curriedInit
@@ -42,7 +42,7 @@ struct TestModelNumerics {
   let uint64String: UInt64
 }
 
-extension TestModelNumerics: Decodable {
+extension TestModelNumerics: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<TestModelNumerics> {
     let f = curry(self.init)
       <^> json <| "int"

--- a/Tests/ArgoTests/Models/URL.swift
+++ b/Tests/ArgoTests/Models/URL.swift
@@ -1,7 +1,7 @@
 import Argo
 import Foundation
 
-extension URL: Decodable {
+extension URL: Argo.Decodable {
   public static func decode(_ json: JSON) -> Decoded<URL> {
     switch json {
     case .string(let urlString):

--- a/Tests/ArgoTests/Models/User.swift
+++ b/Tests/ArgoTests/Models/User.swift
@@ -8,7 +8,7 @@ struct User {
   let email: String?
 }
 
-extension User: Decodable {
+extension User: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<User> {
     return curry(self.init)
       <^> json <| "id"

--- a/Tests/ArgoTests/Tests/DecodedTests.swift
+++ b/Tests/ArgoTests/Tests/DecodedTests.swift
@@ -194,7 +194,7 @@ class DecodedTests: XCTestCase {
   }
 }
 
-private struct Dummy: Decodable {
+private struct Dummy: Argo.Decodable {
   static func decode(_ json: JSON) -> Decoded<Dummy> {
     return .customError("My Custom Error")
   }

--- a/Tests/ArgoTests/Tests/RawRepresentableTests.swift
+++ b/Tests/ArgoTests/Tests/RawRepresentableTests.swift
@@ -11,8 +11,8 @@ enum TestRawInt: Int {
   case one
 }
 
-extension TestRawString: Decodable { }
-extension TestRawInt: Decodable { }
+extension TestRawString: Argo.Decodable { }
+extension TestRawInt: Argo.Decodable { }
 
 class RawRepresentable: XCTestCase {
   func testStringEnum() {


### PR DESCRIPTION
This updates the test suite for Swift 4 (basically just disambiguating `Argo.Decodable` from `Swift.Decodable`) and updates the test suite/package definition so that we can run the tests using `swift test`.

Note that this also _removes_ support for running the tests from Xcode. See 422be95 for the reasoning behind this change.