### PR TITLE
Rename RawRepresentable to RawRepresentableTests to avoid name conflicts

### DIFF
--- a/Tests/ArgoTests/Tests/RawRepresentableTests.swift
+++ b/Tests/ArgoTests/Tests/RawRepresentableTests.swift
@@ -14,7 +14,7 @@ enum TestRawInt: Int {
 extension TestRawString: Argo.Decodable { }
 extension TestRawInt: Argo.Decodable { }
 
-class RawRepresentable: XCTestCase {
+class RawRepresentableTests: XCTestCase {
   func testStringEnum() {
     let json = JSON.object([
       "string": JSON.string("CoolString"),


### PR DESCRIPTION
When I'm importing the test suite on Linux in a `LinuxMain.swift` it is complaining about a name conflict.

Presumably this was just a typo to begin with so I'm proposing this fix. Otherwise, I can just do `Argo.RawRepresentable`. Though that just seem suboptimal.