### PR TITLE
README: replace the `<|` operators with `[]` in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ struct User {
 extension User: Decodable {
   static func decode(_ json: JSON) -> Decoded<User> {
     return curry(User.init)
-      <^> json <| "id"
-      <*> json <| "name"
-      <*> json <|? "email" // Use ? for parsing optional values
-      <*> json <| "role" // Custom types that also conform to Decodable just work
-      <*> json <| ["company", "name"] // Parse nested objects
-      <*> json <|| "friends" // parse arrays of objects
+      <^> json["id"]
+      <*> json["name"]
+      <*> json[optional: "email"] // Use `[optional:]` for parsing optional values
+      <*> json["role"] // Custom types that also conform to Decodable just work
+      <*> json["company", "name"] // Parse nested objects
+      <*> json["friends"] // parse arrays of objects
   }
 }
 


### PR DESCRIPTION
This is to follow-up the [PR][] that removed `<|` operators from the
code.

[PR]: https://github.com/thoughtbot/Argo/pull/488